### PR TITLE
✨ 增加 --dart-define 的支持

### DIFF
--- a/packages/app_package_publisher_fir/lib/src/app_package_publisher_fir.dart
+++ b/packages/app_package_publisher_fir/lib/src/app_package_publisher_fir.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:app_package_publisher/app_package_publisher.dart';
 import 'package:dio/dio.dart';
-import 'package:dio/src/dio_error.dart';
 import 'package:parse_app_package/parse_app_package.dart';
 
 import 'publish_fir_config.dart';

--- a/packages/flutter_distributor/bin/command_package.dart
+++ b/packages/flutter_distributor/bin/command_package.dart
@@ -9,6 +9,8 @@ class CommandPackage extends Command {
     argParser.addOption('build-flavor', valueHelp: '');
     argParser.addOption('build-target-platform', valueHelp: '');
     argParser.addOption('build-export-options-plist', valueHelp: '');
+    argParser.addOption('build-dart-define',
+        valueHelp: 'foo=bar', help: 'Corresponds to --dart-define');
   }
 
   @override


### PR DESCRIPTION
这是一项必要的功能增强✨ ，有助于我们写入环境变量的值作为常量提供给应用程序。
应用场景是打渠道包、环境切换等，比如官方的 `--dart-define=FLUTTER_WEB_USE_SKIA=true` 用于 Flutter Web 启用 Skia

```
flutter_distributor package --help
Usage: flutter_distributor package [arguments]
-h, --help                             Print this usage information.
    --platform=<>
    --targets=<>
    --build-target=<>
    --build-flavor=<>
    --build-target-platform=<>
    --build-export-options-plist=<>
    --build-dart-define=<foo=bar>      The corresponding is --dart-define
```

## 参考
- https://github.com/flutter/flutter/issues/56792
- https://github.com/flutter/flutter/issues/64944

## 其他

去掉了一个无效的 `dio-error.dart` 的引入，因为 `dio.dart` 已经 `export 'src/dio_error.dart';`

![image](https://user-images.githubusercontent.com/8764899/147356785-dd5603e1-600b-4444-bd6f-41bee608ef44.png)

## 测试

```
flutter_distributor package --platform=android --targets=apk --build-dart-define=APP_CHANNEL=beta  --build-dart-define=APP_SERVER_ENV=prod
Running Gradle task 'assembleRelease'...
270.5s
✓  Built build/app/outputs/flutter-apk/app-release.apk (17.1MB).
exitCode: 0
INFO: 2021-12-24 21:03:51.938786: Successfully packaged dist/1.8.0+314/app-1.8.0+314-android.apk
```


