### PR TITLE
[proposal] Add job name to release builds

### DIFF
--- a/packages/app_package_maker/lib/src/app_package_maker.dart
+++ b/packages/app_package_maker/lib/src/app_package_maker.dart
@@ -7,6 +7,10 @@ import 'package:yaml/yaml.dart';
 
 const _kArtifactName = '{name}-{flavor}-{version}-{platform}.{ext}';
 const _kArtifactNameNoFlavor = '{name}-{version}-{platform}.{ext}';
+const _kArtifactNameWithJobName =
+    '{name}-{flavor}-{version}-{platform}-{jobName}.{ext}';
+const _kArtifactNameNoFlavorWithJobName =
+    '{name}-{version}-{platform}-{jobName}.{ext}';
 
 Map<String, dynamic> loadMakeConfigYaml(String path) {
   final yamlDoc = loadYaml(File(path).readAsStringSync());
@@ -29,6 +33,7 @@ abstract class AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
@@ -39,6 +44,7 @@ class MakeConfig {
   String? artifactName;
   late bool isInstaller = false;
   late String platform;
+  String? jobName;
   String? flavor;
   late String packageFormat;
   late Directory outputDirectory;
@@ -54,12 +60,18 @@ class MakeConfig {
       'name': appName,
       'version': appVersion.toString(),
       'platform': platform,
+      'jobName': jobName,
       'flavor': flavor,
       'ext': packageFormat,
     }..removeWhere((key, value) => value == null);
 
     String filename = flavor != null ? _kArtifactName : _kArtifactNameNoFlavor;
     if (artifactName != null) filename = artifactName!;
+    if (jobName != null) {
+      filename = flavor != null
+          ? _kArtifactNameWithJobName
+          : _kArtifactNameNoFlavorWithJobName;
+    }
 
     for (String key in variables.keys) {
       dynamic value = variables[key];

--- a/packages/app_package_maker_aab/lib/src/app_package_maker_aab.dart
+++ b/packages/app_package_maker_aab/lib/src/app_package_maker_aab.dart
@@ -11,11 +11,13 @@ class AppPackageMakerAab extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeConfig makeConfig = await loadMakeConfig()
+      ..jobName = jobName
       ..flavor = flavor
       ..outputDirectory = outputDirectory;
 

--- a/packages/app_package_maker_apk/lib/src/app_package_maker_apk.dart
+++ b/packages/app_package_maker_apk/lib/src/app_package_maker_apk.dart
@@ -18,11 +18,13 @@ class AppPackageMakerApk extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeConfig makeConfig = await loadMakeConfig()
+      ..jobName = jobName
       ..flavor = flavor
       ..outputDirectory = outputDirectory;
 

--- a/packages/app_package_maker_deb/lib/src/app_package_maker_deb.dart
+++ b/packages/app_package_maker_deb/lib/src/app_package_maker_deb.dart
@@ -13,11 +13,13 @@ class AppPackageMakerDeb extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeConfig makeConfig = await loadMakeConfig()
+      ..jobName = jobName
       ..outputDirectory = outputDirectory;
     Directory packagingDirectory = makeConfig.packagingDirectory;
 

--- a/packages/app_package_maker_dmg/lib/src/app_package_maker_dmg.dart
+++ b/packages/app_package_maker_dmg/lib/src/app_package_maker_dmg.dart
@@ -24,11 +24,13 @@ class AppPackageMakerDmg extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeDmgConfig makeConfig = (await loadMakeConfig() as MakeDmgConfig)
+      ..jobName = jobName
       ..outputDirectory = outputDirectory;
     Directory packagingDirectory = makeConfig.packagingDirectory;
 

--- a/packages/app_package_maker_exe/lib/src/app_package_maker_exe.dart
+++ b/packages/app_package_maker_exe/lib/src/app_package_maker_exe.dart
@@ -27,11 +27,13 @@ class AppPackageMakerExe extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeConfig makeConfig = await loadMakeConfig()
+      ..jobName = jobName
       ..outputDirectory = outputDirectory;
     Directory packagingDirectory = makeConfig.packagingDirectory;
 

--- a/packages/app_package_maker_ipa/lib/src/app_package_maker_ipa.dart
+++ b/packages/app_package_maker_ipa/lib/src/app_package_maker_ipa.dart
@@ -11,11 +11,13 @@ class AppPackageMakerIpa extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeConfig makeConfig = await loadMakeConfig()
+      ..jobName = jobName
       ..flavor = flavor
       ..outputDirectory = outputDirectory;
 

--- a/packages/app_package_maker_zip/lib/src/app_package_maker_zip.dart
+++ b/packages/app_package_maker_zip/lib/src/app_package_maker_zip.dart
@@ -18,11 +18,13 @@ class AppPackageMakerZip extends AppPackageMaker {
   Future<MakeResult> make(
     Directory appDirectory, {
     required Directory outputDirectory,
+    String? jobName,
     String? flavor,
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
     MakeConfig makeConfig = await loadMakeConfig()
+      ..jobName = jobName
       ..outputDirectory = outputDirectory;
 
     if (platform == 'windows') {

--- a/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
+++ b/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
@@ -27,6 +27,7 @@ class FlutterAppPackager {
     Directory appDirectory, {
     required Directory outputDirectory,
     required String platform,
+    String? jobName,
     String? flavor,
     required String target,
     void Function(List<int> data)? onProcessStdOut,
@@ -39,6 +40,7 @@ class FlutterAppPackager {
       appDirectory,
       outputDirectory: outputDirectory,
       flavor: flavor,
+      jobName: jobName,
       onProcessStdOut: onProcessStdOut,
       onProcessStdErr: onProcessStdErr,
     );

--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -126,6 +126,7 @@ class FlutterDistributor {
     List<String> targets, {
     required bool cleanBeforeBuild,
     required Map<String, dynamic> buildArguments,
+    String? jobName,
   }) async {
     List<MakeResult> makeResultList = [];
 
@@ -166,6 +167,7 @@ class FlutterDistributor {
           MakeResult makeResult = await _packager.package(
             buildResult.outputDirectory,
             outputDirectory: outputDirectory,
+            jobName: jobName,
             platform: platform,
             flavor: buildArguments['flavor'],
             target: target,
@@ -304,6 +306,7 @@ class FlutterDistributor {
           [job.package.target],
           cleanBeforeBuild: needCleanBeforeBuild,
           buildArguments: job.package.buildArgs ?? {},
+          jobName: job.name,
         );
         // Clean only once
         needCleanBeforeBuild = false;


### PR DESCRIPTION
consider this situation
```yaml
output: dist/
releases:
  - name: release
    jobs:
      - name: arm32
        package:
          platform: android
          target: apk
          build_args:
            target-platform: android-arm
      - name: arm64
        package:
          platform: android
          target: apk
          build_args:
            target-platform: android-arm64
```

 will generate only one build 
* dist/0.0.1+1/app-0.0.1+1-android.apk

> this pr add a feature which will generate multi-builds base on the `jobName`
