### PR TITLE
编译为exe安装程序时，增加make_config的扩展参数

### DIFF
--- a/examples/hello_world/windows/packaging/exe/make_config.yaml
+++ b/examples/hello_world/windows/packaging/exe/make_config.yaml
@@ -1,3 +1,7 @@
 appId: C52EDEB4-E345-4C95-BF90-E2BF83CF2B30
 appPublisher: LeanFlutter
 appPublisherUrl: https://github.com/leanflutter/flutter_distributor
+appDisplayName: TESTNAME
+#appExeFileName: LeanFlutterExeFileName.exe
+defaultDesktopIconCkecked: true
+innoSetupDir: D:\SOFTWARE\Inno Setup 6

--- a/packages/app_package_maker/lib/src/app_package_maker.dart
+++ b/packages/app_package_maker/lib/src/app_package_maker.dart
@@ -49,8 +49,6 @@ class MakeConfig {
   }
 
   String get appName => displayName ?? pubspec.name;
-
-  String get appName => pubspec.name;
   Version get appVersion => pubspec.version!;
 
   Pubspec? _pubspec;

--- a/packages/app_package_maker/lib/src/app_package_maker.dart
+++ b/packages/app_package_maker/lib/src/app_package_maker.dart
@@ -43,6 +43,13 @@ class MakeConfig {
   late String packageFormat;
   late Directory outputDirectory;
 
+  String? displayName;
+  set disPlayName(String? displayname){
+    this.displayName=displayname;
+  }
+
+  String get appName => displayName ?? pubspec.name;
+
   String get appName => pubspec.name;
   Version get appVersion => pubspec.version!;
 

--- a/packages/app_package_maker_exe/lib/src/app_package_maker_exe.dart
+++ b/packages/app_package_maker_exe/lib/src/app_package_maker_exe.dart
@@ -15,7 +15,7 @@ class AppPackageMakerExe extends AppPackageMaker {
   bool get isSupportedOnCurrentPlatform => Platform.isWindows;
 
   @override
-  Future<MakeConfig> loadMakeConfig() async {
+  Future<MakeExeConfig> loadMakeConfig() async {
     final map = loadMakeConfigYaml('windows/packaging/exe/make_config.yaml');
     return MakeExeConfig.fromJson(map)
       ..isInstaller = true
@@ -31,12 +31,16 @@ class AppPackageMakerExe extends AppPackageMaker {
     void Function(List<int> data)? onProcessStdOut,
     void Function(List<int> data)? onProcessStdErr,
   }) async {
-    MakeConfig makeConfig = await loadMakeConfig()
+    MakeExeConfig makeConfig = await loadMakeConfig()
       ..outputDirectory = outputDirectory;
+    if(makeConfig.appDisplayName!=null&&makeConfig.appDisplayName!.isNotEmpty){
+      makeConfig.displayName = makeConfig.appDisplayName!;
+    }
     Directory packagingDirectory = makeConfig.packagingDirectory;
 
     Directory innoSetupDirectory =
-        Directory('C:\\Program Files (x86)\\Inno Setup 6');
+    Directory(makeConfig.innoSetupDir ?? 'C:\\Program Files (x86)\\Inno Setup 6');
+
 
     if (!innoSetupDirectory.existsSync()) {
       throw Exception('`Inno Setup 6` was not installed.');

--- a/packages/app_package_maker_exe/lib/src/create_setup_script_file.dart
+++ b/packages/app_package_maker_exe/lib/src/create_setup_script_file.dart
@@ -13,6 +13,8 @@ String _issFileTemplate = """
 
 #define MyAppPackagingDir "{{appPackagingDir}}"
 #define MyAppOutputBaseFilename "{{appOutputBaseFilename}}"
+#define DeskTopIconChecked "{{deskTopIconChecked}}"
+
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -40,7 +42,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 ;Name: "chinesesimplified"; MessagesFile: "compiler:Languages\\ChineseSimplified.isl"
 
 [Tasks]
-Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}";{#DeskTopIconChecked}
 
 [Files]
 Source: "{#MyAppPackagingDir}\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -67,10 +69,11 @@ Future<File> createSetupScriptFile(MakeExeConfig makeConfig) async {
     'appVersion': makeConfig.appVersion.toString(),
     'appPublisher': makeConfig.appPublisher ?? '',
     'appPublisherUrl': makeConfig.appPublisherUrl ?? '',
-    'appExeName': p.basename(exeFile.path),
+    'appExeName': makeConfig.appExeFileName ?? p.basename(exeFile.path),
     'appPackagingDir': p.basename(makeConfig.packagingDirectory.path),
     'appOutputBaseFilename':
         p.basename(makeConfig.outputFile.path).replaceAll('.exe', ''),
+    'deskTopIconChecked':makeConfig.defaultDesktopIconCkecked ? "" : " Flags: unchecked"
   };
 
   String content = _issFileTemplate;

--- a/packages/app_package_maker_exe/lib/src/make_exe_config.dart
+++ b/packages/app_package_maker_exe/lib/src/make_exe_config.dart
@@ -4,18 +4,31 @@ class MakeExeConfig extends MakeConfig {
   final String appId;
   String? appPublisher;
   String? appPublisherUrl;
+  String? appDisplayName;
+  String? appExeFileName;
+  String? innoSetupDir;
+  bool defaultDesktopIconCkecked;
 
   MakeExeConfig({
     required this.appId,
     this.appPublisher,
     this.appPublisherUrl,
+    this.appDisplayName,
+    this.appExeFileName,
+    this.innoSetupDir,
+    this.defaultDesktopIconCkecked=false,
   });
+
 
   factory MakeExeConfig.fromJson(Map<String, dynamic> json) {
     return MakeExeConfig(
       appId: json['appId'],
       appPublisher: json['appPublisher'],
       appPublisherUrl: json['appPublisherUrl'],
+      appDisplayName: json['appDisplayName'],
+      appExeFileName: json['appExeFileName'],
+      innoSetupDir: json['innoSetupDir'],
+      defaultDesktopIconCkecked: json['defaultDesktopIconCkecked'],
     );
   }
 
@@ -24,6 +37,10 @@ class MakeExeConfig extends MakeConfig {
       'appId': appId,
       'appPublisher': appPublisher,
       'appPublisherUrl': appPublisherUrl,
+      'appDisplayName': appDisplayName,
+      'appExeFileName': appExeFileName,
+      'innoSetupDir': innoSetupDir,
+      'defaultDesktopIconCkecked': defaultDesktopIconCkecked,
     }..removeWhere((key, value) => value == null);
   }
 }


### PR DESCRIPTION
make_config中添加扩展参数
新增

1. appDisplayName--可替代默认appName(应用名,暂不支持中文)
2. appExeFileName--可替代默认可执行程序名(如:hello_world.exe)
3. defaultDesktopIconCkecked--可配置是否默认勾选“创建桌面快捷方式”默认为不勾选
4. innoSetupDir--可动态配置InnoSetup的安装路径，默认为C:\Program Files (x86)\Inno Setup 6