### PR TITLE
fix build_args map entries value may null

### DIFF
--- a/packages/flutter_app_builder/lib/src/app_builder.dart
+++ b/packages/flutter_app_builder/lib/src/app_builder.dart
@@ -30,7 +30,9 @@ class AppBuilder {
     List<String> arguments = [];
     for (String key in buildArguments.keys) {
       dynamic value = buildArguments[key];
-      if (value is Map) {
+      if (value == null) {
+        arguments.add('--$key');
+      } else if (value is Map) {
         for (String subKey in value.keys) {
           arguments.addAll(['--$key', '$subKey=${value[subKey]}']);
         }


### PR DESCRIPTION
this `distribute_options.yaml`
```yaml
...
  - name: android
    jobs:    
      - name: arm
        package:
          platform: android
          target: apk
          build_args:
            flavor: arm
            obfuscate:
            split-debug-info: .
...
```
will cause `type 'Null' is not a subtype of type 'String'` issue

```
type 'Null' is not a subtype of type 'String'
#0      AppBuilder.build (package:flutter_app_builder/src/app_builder.dart:38:37)
#1      FlutterAppBuilder.build (package:flutter_app_builder/src/flutter_app_builder.dart:42:26)
#2      FlutterDistributor.package (package:flutter_distributor/src/flutter_distributor.dart:145:40)
#3      FlutterDistributor.release (package:flutter_distributor/src/flutter_distributor.dart:302:49)
```
