### PR TITLE
fix:fir may response without code

### DIFF
--- a/packages/app_package_publisher_fir/lib/src/app_package_publisher_fir.dart
+++ b/packages/app_package_publisher_fir/lib/src/app_package_publisher_fir.dart
@@ -101,7 +101,7 @@ class AppPackagePublisherFir extends AppPackagePublisher {
     } on DioError catch (error) {
       String? message;
       if (error.response?.data != null) {
-        int code = error.response?.data['code'];
+        int? code = error.response?.data['code'];
         message = error.response?.data['errors']['exception'][0];
         message = '$code - $message';
       }


### PR DESCRIPTION
when use a unauthenticated fir accounts, api response doesnt contain code .
```json
{"msg": "没有实名认证不能上传app"}
```