### PR TITLE
Version 0.2.4+1: Fix an incorrectly worded message

### DIFF
--- a/packages/flutter_distributor/CHANGELOG.md
+++ b/packages/flutter_distributor/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.4+1
+* Fix an incorrectly worded message
+
 ## 0.2.4
 
 * [dmg maker] Support `code-sign` configuration item.

--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -159,7 +159,7 @@ class FlutterDistributor {
             },
           );
           logger.info(
-            Colorize('Successfully builded ${buildResult.outputDirectory}')
+            Colorize('Successfully built ${buildResult.outputDirectory}')
                 .green(),
           );
         }

--- a/packages/flutter_distributor/pubspec.yaml
+++ b/packages/flutter_distributor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_distributor
 description: A complete tool for packaging and publishing your Flutter apps.
-version: 0.2.4
+version: 0.2.4+1
 homepage: https://github.com/leanflutter/flutter_distributor
 
 platforms:


### PR DESCRIPTION
Replaces the incorrect word "builded" with the correct word "built"