### PR TITLE
Feat: Linux RPM packaging support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ The full documentation can be found on [distributor.leanflutter.org](https://dis
 
 - [apk](./packages/flutter_app_packager/lib/src/makers/apk/) - Create a `apk` package for your app.
 - [aab](./packages/flutter_app_packager/lib/src/makers/aab/) - Create a `aab` package for your app.
+- [appimage](./packages/flutter_app_packager/lib/src/makers/appimage/) - Create a `AppImage` package for your app.
 - [deb](./packages/flutter_app_packager/lib/src/makers/deb/) - Create a `deb` package for your app.
 - [dmg](./packages/flutter_app_packager/lib/src/makers/dmg/) - Create a `dmg` package for your app.
 - [exe](./packages/flutter_app_packager/lib/src/makers/exe/) - Create a `exe` package for your app.
 - [ipa](./packages/flutter_app_packager/lib/src/makers/ipa/) - Create a `ipa` package for your app.
 - [msix](./packages/flutter_app_packager/lib/src/makers/msix/) - Create a `msix` package for your app.
+- [rpm](./packages/flutter_app_packager/lib/src/makers/rpm/) - Create a `rpm` package for your app.
 - [zip](./packages/flutter_app_packager/lib/src/makers/zip/) - Create a `zip` package for your app.
 
 ### Publishers

--- a/docs/en/makers/appimage.md
+++ b/docs/en/makers/appimage.md
@@ -1,0 +1,50 @@
+---
+title: AppImage
+---
+
+## Requirements
+- [AppImage Builder](https://github.com/AppImageCrafters/appimage-builder)
+
+To install Appimage Builder, run:
+
+```bash
+wget -O appimage-builder https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
+chmod +x appimage-builder
+mv appimage-builder /usr/local/bin/
+```
+> Last command may require `sudo` privileges
+
+## Usage
+
+Add `make_config.yaml` to your project `linux/packaging/appimage` directory.
+
+```yaml
+appId: org.leanflutter.examples.hello_world
+icon: assets/logo.png
+
+script:
+  - echo 'Running a Script'
+
+include: []
+exclude: []
+# its true by default
+default_excludes: true
+
+files:
+  include: []
+  exclude: []
+  # its true by default
+  default_excludes: true
+```
+
+
+Run:
+
+```bash
+flutter_distributor package --platform linux --targets appimage
+```
+
+## Related Links
+
+* [Build and release an Linux app](https://docs.flutter.dev/deployment/linux)
+* [Introduction to AppImage package format](https://docs.appimage.org/)

--- a/docs/en/makers/deb.md
+++ b/docs/en/makers/deb.md
@@ -2,7 +2,45 @@
 title: deb
 ---
 
-## Usage
+Add `make_config.yaml` to your project `linux/packaging/deb` directory.
+
+```yaml
+display_name: Hello World
+package_name: hello-world
+maintainer:
+  name: LiJianying
+  email: lijy91@foxmail.com
+co_authors:
+  - name: Kingkor Roy Tirtho
+    email: krtirtho@gmail.com
+priority: optional
+section: x11
+installed_size: 6604
+essential: false
+icon: assets/logo.png
+
+postinstall_scripts:
+  - echo `Installed my awesome app`
+postuninstall_scripts:
+  - echo `Surprised Pickachu face`
+
+
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
+
+generic_name: Music Application
+
+
+
+categories:
+  - Music
+  - Media
+
+startup_notify: true
+```
 
 Run:
 
@@ -10,6 +48,6 @@ Run:
 flutter_distributor package --platform linux --targets deb
 ```
 
-## Related Links
 
 * [Build and release an Linux app](https://docs.flutter.dev/deployment/linux)
+* [Packaging Debian packages, how it works](https://www.debian.org/doc/manuals/packaging-tutorial/packaging-tutorial.en.pdf)

--- a/docs/en/makers/exe.md
+++ b/docs/en/makers/exe.md
@@ -4,7 +4,7 @@ title: exe
 
 ## Requirements
 
-* [`Inno Setup 6`](https://jrsoftware.org/isinfo.php)``
+* [`Inno Setup 6`](https://jrsoftware.org/isinfo.php)
 
 ## Usage
 

--- a/docs/en/makers/rpm.md
+++ b/docs/en/makers/rpm.md
@@ -1,0 +1,54 @@
+---
+title: RPM
+---
+
+## Requires
+
+- [rpmbuild](https://rpm-packaging-guide.github.io/#prerequisites)
+
+Install `rpmbuild`:
+- Debian/Ubuntu: `apt install rpm`
+- Fedora: `dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools`
+- Arch: `yay -S rpmdevtools` or `pamac install rpmdevtools`
+
+## Usage
+
+Add `make_config.yaml` to your project `linux/packaging/rpm` directory.
+
+```yaml
+icon: assets/logo.png
+summary: A really cool application
+group: Application/Emulator
+vendor: Kingkor Roy Tirtho
+packager: Kingkor Roy Tirtho
+packagerEmail: krtirtho@gmail.com
+license: GPLv3
+url: https://github.com/leanflutter/flutter_distributor
+
+display_name: Hello World
+
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
+
+generic_name: Cool Application
+
+categories:
+  - Cool
+  - Awesome
+
+startup_notify: true
+```
+
+Run:
+
+```
+flutter_distributor package --platform linux --targets deb
+```
+
+## Related Links
+
+* [Build and release an Linux app](https://docs.flutter.dev/deployment/linux)
+* [RPM packaging, how it works](https://rpm-packaging-guide.github.io/)

--- a/docs/zh/makers/appimage.md
+++ b/docs/zh/makers/appimage.md
@@ -1,0 +1,50 @@
+---
+title: AppImage
+---
+
+## 要求
+- [AppImage Builder](https://github.com/AppImageCrafters/appimage-builder)
+
+要安装 Appimage Builder，请运行：
+
+```bash
+wget -O appimage-builder https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
+chmod +x appimage-builder
+mv appimage-builder /usr/local/bin/
+```
+> Last command may require `sudo` privileges
+
+## 用法
+
+将 `make_config.yaml` 添加到您的项目 `linux/packaging/appimage` 目录。
+
+```yaml
+appId: org.leanflutter.examples.hello_world
+icon: assets/logo.png
+
+script:
+  - echo 'Running a Script'
+
+include: []
+exclude: []
+# 默认为真
+default_excludes: true
+
+files:
+  include: []
+  exclude: []
+  # 默认为真
+  default_excludes: true
+```
+
+
+跑:
+
+```bash
+flutter_distributor package --platform linux --targets appimage
+```
+
+## 相关链接
+
+* [构建和发布 Linux 应用程序](https://docs.flutter.dev/deployment/linux)
+* [AppImage包格式介绍](https://docs.appimage.org/)

--- a/docs/zh/makers/deb.md
+++ b/docs/zh/makers/deb.md
@@ -2,14 +2,49 @@
 title: deb
 ---
 
-## 用法
+将 `make_config.yaml` 添加到您的项目 `linux/packaging/deb` 目录。
 
-运行：
+```yaml
+display_name: Hello World
+package_name: hello-world
+maintainer:
+  name: LiJianying
+  email: lijy91@foxmail.com
+co_authors:
+  - name: Kingkor Roy Tirtho
+    email: krtirtho@gmail.com
+priority: optional
+section: x11
+installed_size: 6604
+essential: false
+icon: assets/logo.png
+
+postinstall_scripts:
+  - echo `Installed my awesome app`
+postuninstall_scripts:
+  - echo `Surprised Pickachu face`
+
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
+
+generic_name: Music Application
+
+categories:
+  - Music
+  - Media
+
+startup_notify: true
+```
+
+跑:
 
 ```
 flutter_distributor package --platform linux --targets deb
 ```
 
-## 相关链接
 
-* [Build and release an Linux app](https://docs.flutter.dev/deployment/linux)
+* [构建和发布 Linux 应用程序](https://docs.flutter.dev/deployment/linux)
+* [打包 Debian 软件包，它是如何工作的](https://www.debian.org/doc/manuals/packaging-tutorial/packaging-tutorial.en.pdf)

--- a/docs/zh/makers/rpm.md
+++ b/docs/zh/makers/rpm.md
@@ -1,0 +1,54 @@
+---
+title: RPM
+---
+
+## 要求
+
+- [rpmbuild](https://rpm-packaging-guide.github.io/#prerequisites)
+
+安装 `rpmbuild`:
+- Debian/Ubuntu: `apt install rpm`
+- Fedora: `dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools`
+- Arch: `yay -S rpmdevtools` or `pamac install rpmdevtools`
+
+## 用法
+
+将 `make_config.yaml` 添加到您的项目 `linux/packaging/rpm` 目录。
+
+```yaml
+icon: assets/logo.png
+summary: A really cool application
+group: Application/Emulator
+vendor: Kingkor Roy Tirtho
+packager: Kingkor Roy Tirtho
+packagerEmail: krtirtho@gmail.com
+license: GPLv3
+url: https://github.com/leanflutter/flutter_distributor
+
+display_name: Hello World
+
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
+
+generic_name: Cool Application
+
+categories:
+  - Cool
+  - Awesome
+
+startup_notify: true
+```
+
+跑:
+
+```
+flutter_distributor package --platform linux --targets deb
+```
+
+## 相关链接
+
+* [构建和发布 Linux 应用程序](https://docs.flutter.dev/deployment/linux)
+* [RPM 打包，它是如何工作的](https://rpm-packaging-guide.github.io/)

--- a/examples/hello_world/linux/packaging/rpm/make_config.yaml
+++ b/examples/hello_world/linux/packaging/rpm/make_config.yaml
@@ -1,0 +1,24 @@
+icon: assets/logo.png
+summary: A really cool application
+group: Application/Emulator
+vendor: Kingkor Roy Tirtho
+packager: Kingkor Roy Tirtho
+packagerEmail: krtirtho@gmail.com
+license: GPLv3
+url: https://github.com/leanflutter/flutter_distributor
+
+display_name: Hello World
+
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
+
+generic_name: Cool Application
+
+categories:
+  - Cool
+  - Awesome
+
+startup_notify: true

--- a/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
+++ b/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
@@ -12,6 +12,7 @@ class FlutterAppPackager {
     AppPackageMakerExe(),
     AppPackageMakerIpa(),
     AppPackageMakerMsix(),
+    AppPackageMakerRPM(),
     AppPackageMakerZip('linux'),
     AppPackageMakerZip('macos'),
     AppPackageMakerZip('windows'),

--- a/packages/flutter_app_packager/lib/src/makers/deb/app_package_maker_deb.dart
+++ b/packages/flutter_app_packager/lib/src/makers/deb/app_package_maker_deb.dart
@@ -71,10 +71,18 @@ class AppPackageMakerDeb extends AppPackageMaker {
       if (!iconFile.existsSync())
         throw MakeError("provided icon ${makeConfig.icon} path wasn't found");
 
-      await iconFile
-          .copy(path.join(icon128Dir, path.basename(makeConfig.icon!)));
-      await iconFile
-          .copy(path.join(icon256Dir, path.basename(makeConfig.icon!)));
+      await iconFile.copy(
+        path.join(
+          icon128Dir,
+          makeConfig.appName + path.extension(makeConfig.icon!),
+        ),
+      );
+      await iconFile.copy(
+        path.join(
+          icon256Dir,
+          makeConfig.appName + path.extension(makeConfig.icon!),
+        ),
+      );
     }
 
     // create & write the files got from makeConfig

--- a/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
@@ -292,7 +292,7 @@ class MakeDebConfig extends MakeConfig {
         "Version": appVersion.toString(),
         "Name": displayName,
         "GenericName": genericName,
-        "Icon": icon != null ? path.basenameWithoutExtension(icon!) : null,
+        "Icon": appName,
         "Exec": "$appName %U",
         "Actions": actions != null && actions!.isNotEmpty
             ? actions!.join(";") + ";"

--- a/packages/flutter_app_packager/lib/src/makers/makers.dart
+++ b/packages/flutter_app_packager/lib/src/makers/makers.dart
@@ -4,6 +4,7 @@ export 'aab/app_package_maker_aab.dart';
 export 'apk/app_package_maker_apk.dart';
 export 'appimage/app_package_maker_appimage.dart';
 export 'deb/app_package_maker_deb.dart';
+export 'rpm/app_package_maker_rpm.dart';
 export 'dmg/app_package_maker_dmg.dart';
 export 'exe/app_package_maker_exe.dart';
 export 'ipa/app_package_maker_ipa.dart';

--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -88,7 +88,12 @@ class AppPackageMakerRPM extends AppPackageMaker {
         ? File(path.join(Directory.current.path, makeConfig.icon!))
         : null;
 
-    iconFile?.copy(path.join(buildPath, "${makeConfig.appName}.png"));
+    iconFile?.copy(
+      path.join(
+        buildPath,
+        makeConfig.appName + path.extension(iconFile.path),
+      ),
+    );
 
     if (makeConfig.icon != null) {
       final iconFile = File(makeConfig.icon!);

--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:app_package_maker/app_package_maker.dart';
+import 'package:shell_executor/shell_executor.dart';
+
+import 'make_rpm_config.dart';
+
+class AppPackageMakerRPM extends AppPackageMaker {
+  String get name => 'rpm';
+  String get platform => 'linux';
+  String get packageFormat => 'rpm';
+
+  bool get isSupportedOnCurrentPlatform => Platform.isLinux;
+
+  @override
+  Future<MakeConfig> loadMakeConfig(
+      Directory outputDirectory, Map<String, dynamic>? makeArguments) async {
+    final makeConfig =
+        await super.loadMakeConfig(outputDirectory, makeArguments);
+    return MakeRPMConfig.fromJson(
+            loadMakeConfigYaml("linux/packaging/rpm/make_config.yaml"))
+        .copyWith(makeConfig);
+  }
+
+  @override
+  Future<MakeResult> make(
+    Directory appDirectory, {
+    required Directory outputDirectory,
+    Map<String, dynamic>? makeArguments,
+  }) async {
+    MakeRPMConfig makeConfig = await loadMakeConfig(
+      outputDirectory,
+      makeArguments,
+    ) as MakeRPMConfig;
+
+    final files = makeConfig.toFilesString();
+
+    Directory packagingDirectory = makeConfig.packagingDirectory;
+
+    // making rpm setup directory
+
+    final rpmbuild = [
+      "BUILD",
+      "BUILDROOT",
+      "RPMS",
+      "SOURCES",
+      "SPECS",
+      "SRPMS",
+    ];
+
+    final rpmbuildDirPath =
+        path.join(packagingDirectory.absolute.path, "rpmbuild");
+
+    for (final dir in rpmbuild) {
+      final dirPath = path.join(rpmbuildDirPath, dir);
+      final dirFile = Directory(dirPath);
+      if (!dirFile.existsSync()) {
+        dirFile.createSync(recursive: true);
+      }
+    }
+
+    // making rpmbuild/BUILD/[appName] directory
+    final buildPath = path.join(rpmbuildDirPath, "BUILD");
+    final buildRoot = path.join(buildPath, makeConfig.appName);
+    final specsPath = path.join(rpmbuildDirPath, "SPECS");
+    final rpmPath =
+        path.join(rpmbuildDirPath, "RPMS", makeConfig.buildArch ?? "x86_64");
+    final buildWivesDirFile = Directory(buildRoot);
+    if (!buildWivesDirFile.existsSync()) {
+      buildWivesDirFile.createSync(recursive: true);
+    }
+
+    /// copying app files to rpmbuild/BUILD/[appName] directory
+    final bundleFiles = appDirectory.listSync();
+    for (final file in bundleFiles) {
+      await $(
+        "cp",
+        [
+          "-r",
+          file.path,
+          buildRoot,
+        ],
+      );
+    }
+
+    final iconFile = makeConfig.icon != null
+        ? File(path.join(Directory.current.path, makeConfig.icon!))
+        : null;
+
+    iconFile?.copy(path.join(buildPath, "${makeConfig.appName}.png"));
+
+    if (makeConfig.icon != null) {
+      final iconFile = File(makeConfig.icon!);
+      if (!iconFile.existsSync())
+        throw MakeError("provided icon ${makeConfig.icon} path wasn't found");
+    }
+
+    // create & write the files got from makeConfig
+    final specFile = File(path.join(specsPath, "${makeConfig.appName}.spec"));
+    final desktopEntryFile =
+        File(path.join(buildPath, "${makeConfig.appName}.desktop"));
+
+    if (!specFile.existsSync()) specFile.createSync();
+    if (!desktopEntryFile.existsSync()) desktopEntryFile.createSync();
+
+    await specFile.writeAsString(files["SPEC"]!);
+    await desktopEntryFile.writeAsString(files["DESKTOP"]!);
+
+    // make the rpm
+    final processResult = await $(
+      "rpmbuild",
+      [
+        "--define",
+        "_topdir ${rpmbuildDirPath}",
+        "-bb",
+        specFile.path,
+      ],
+      environment: {"QA_RPATHS": "19"},
+    );
+
+    if (processResult.exitCode != 0) {
+      throw MakeError();
+    }
+
+    final rpms = Directory(rpmPath).listSync();
+    for (var rpm in rpms) {
+      if (rpm is! File) continue;
+      await $(
+        "cp",
+        [
+          rpm.path,
+          makeConfig.outputFile.path,
+        ],
+      );
+      break;
+    }
+    packagingDirectory.deleteSync(recursive: true);
+    return MakeResult(makeConfig);
+  }
+}

--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -116,7 +116,7 @@ class AppPackageMakerRPM extends AppPackageMaker {
         "-bb",
         specFile.path,
       ],
-      environment: {"QA_RPATHS": "19"},
+      environment: {"QA_RPATHS": (0x0001 | 0x0002 | 0x0010).toString()},
     );
 
     if (processResult.exitCode != 0) {

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -1,0 +1,201 @@
+import 'package:app_package_maker/app_package_maker.dart';
+import 'package:path/path.dart' as path;
+
+class MakeRPMConfig extends MakeConfig {
+  String displayName;
+  String? icon;
+  String? genericName;
+  bool? startupNotify;
+  List<String>? keywords;
+  List<String>? supportedMimeType;
+  List<String>? actions;
+  List<String>? categories;
+
+  //RPM preamble Spec file fields
+  String? summary;
+  String? group;
+  String? vendor;
+  String? packager;
+  String? packagerEmail;
+  String? license;
+  String? url;
+  String? buildArch;
+  List<String>? requires;
+  List<String>? buildRequires;
+  //RPM postamble Spec file fields
+  String? description;
+  String? prep;
+  String? build;
+  String? install;
+  String? postun;
+  String? files;
+  String? defattr;
+  String? attr;
+  String? changelog;
+
+  MakeRPMConfig({
+    // Desktop file
+    required this.displayName,
+    this.startupNotify = true,
+    this.actions,
+    this.categories,
+    this.genericName,
+    this.icon,
+    this.keywords,
+    this.supportedMimeType,
+
+    // Spec file
+    this.summary,
+    this.group,
+    this.vendor,
+    this.packager,
+    this.packagerEmail,
+    this.license,
+    this.url,
+    this.buildArch,
+    this.requires,
+    this.buildRequires,
+    this.description,
+    this.prep,
+    this.build,
+    this.install,
+    this.postun,
+    this.files,
+    this.defattr,
+    this.attr,
+    this.changelog,
+  });
+
+  factory MakeRPMConfig.fromJson(Map<String, dynamic> json) {
+    return MakeRPMConfig(
+      displayName: json['display_name'] as String,
+      icon: json['icon'] as String?,
+      genericName: json['generic_name'] as String?,
+      startupNotify: json['startup_notify'] as bool?,
+      keywords: (json['keywords'] as List<dynamic>?)?.cast<String>(),
+      supportedMimeType:
+          (json['supported_mime_type'] as List<dynamic>?)?.cast<String>(),
+      actions: (json['actions'] as List<dynamic>?)?.cast<String>(),
+      categories: (json['categories'] as List<dynamic>?)?.cast<String>(),
+      summary: json['summary'] as String?,
+      group: json['group'] as String?,
+      vendor: json['vendor'] as String?,
+      packager: json['packager'] as String?,
+      packagerEmail: json['packagerEmail'] as String?,
+      license: json['license'] as String?,
+      url: json['url'] as String?,
+      buildArch: json['build_arch'] as String?,
+      requires: (json['requires'] as List<dynamic>?)?.cast<String>(),
+      buildRequires: (json['build_requires'] as List<dynamic>?)?.cast<String>(),
+      description: json['description'] as String?,
+      prep: json['prep'] as String?,
+      build: json['build'] as String?,
+      install: json['install'] as String?,
+      postun: json['postun'] as String?,
+      files: json['files'] as String?,
+      defattr: json['defattr'] as String?,
+      attr: json['attr'] as String?,
+      changelog: json['changelog'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      "SPEC": {
+        "preamble": {
+          "Name": appName,
+          "Version": appVersion.toString(),
+          "Release":
+              "${appVersion.build.isNotEmpty ? appVersion.build.first : "1"}%{?dist}",
+          "Summary": summary ?? pubspec.description,
+          "Group": group,
+          "Vendor": vendor,
+          "Packager":
+              packagerEmail != null ? "$packager <$packagerEmail>" : packager,
+          "License": license,
+          "URL": url,
+          "Requires": requires?.join(";"),
+          "BuildRequires": buildRequires?.join(";"),
+          "BuildArch": buildArch ?? "x86_64",
+        }..removeWhere((key, value) => value == null),
+        "body": {
+          "%description": description ?? pubspec.description,
+          "%install": [
+            "mkdir -p %{buildroot}%{_bindir}",
+            "mkdir -p %{buildroot}%{_datadir}/%{name}",
+            "mkdir -p %{buildroot}%{_datadir}/applications",
+            "mkdir -p %{buildroot}%{_datadir}/pixmaps",
+            "cp -r %{name}/* %{buildroot}%{_datadir}/%{name}",
+            "ln -s %{_datadir}/%{name}/%{name} %{buildroot}%{_bindir}/%{name}",
+            "cp -r %{name}.desktop %{buildroot}%{_datadir}/applications",
+            "cp -r %{name}.png %{buildroot}%{_datadir}/pixmaps",
+            "update-mime-database %{_datadir}/mime &> /dev/null || :",
+          ].join("\n"),
+          "%postun": ["update-mime-database %{_datadir}/mime &> /dev/null || :"]
+              .join("\n"),
+          "%files": [
+            "%{_bindir}/%{name}",
+            "%{_datadir}/%{name}",
+            "%{_datadir}/applications/%{name}.desktop",
+          ].join("\n"),
+        }..removeWhere((key, value) => value == null),
+        "inline-body": {
+          "%defattr": "(-,root,root)",
+          "%attr": "(4755, root, root) %{_datadir}/pixmaps/%{name}.png",
+        }
+      },
+      "DESKTOP": {
+        "Type": "Application",
+        "Version": appVersion.toString(),
+        "Name": displayName,
+        "GenericName": genericName,
+        "Icon": icon != null ? path.basenameWithoutExtension(icon!) : null,
+        "Exec": "$appName %U",
+        "Actions": actions != null && actions!.isNotEmpty
+            ? actions!.join(";") + ";"
+            : null,
+        "MimeType": supportedMimeType != null && supportedMimeType!.isNotEmpty
+            ? supportedMimeType!.join(";") + ";"
+            : null,
+        "Categories": categories != null && categories!.isNotEmpty
+            ? categories!.join(";") + ";"
+            : null,
+        "Keywords": keywords != null && keywords!.isNotEmpty
+            ? keywords!.join(";") + ";"
+            : null,
+        "StartupNotify": startupNotify
+      }..removeWhere((key, value) => value == null),
+    };
+  }
+
+  Map<String, String> toFilesString() {
+    final json = toJson();
+
+    final preamble = (json["SPEC"]["preamble"] as Map)
+        .entries
+        .map((e) => "${e.key}: ${e.value}")
+        .join("\n");
+    final body = (json["SPEC"]["body"] as Map).entries.map(
+      (e) {
+        return "${e.key}\n${e.value}\n";
+      },
+    ).join("\n");
+    final inlineBody = (json["SPEC"]["inline-body"] as Map).entries.map(
+      (e) {
+        return "${e.key}${e.value}\n";
+      },
+    ).join("\n");
+
+    final desktopFile = [
+      "[Desktop Entry]",
+      ...(json["DESKTOP"] as Map<String, dynamic>).entries.map(
+            (e) => "${e.key}=${e.value}",
+          ),
+    ].join("\n");
+    final map = {
+      "DESKTOP": desktopFile,
+      "SPEC": "$preamble\n\n$body\n\n$inlineBody",
+    };
+    return Map.castFrom<String, String?, String, String>(map);
+  }
+}

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -114,8 +114,8 @@ class MakeRPMConfig extends MakeConfig {
               packagerEmail != null ? "$packager <$packagerEmail>" : packager,
           "License": license,
           "URL": url,
-          "Requires": requires?.join(";"),
-          "BuildRequires": buildRequires?.join(";"),
+          "Requires": requires?.join(", "),
+          "BuildRequires": buildRequires?.join(", "),
           "BuildArch": buildArch ?? "x86_64",
         }..removeWhere((key, value) => value == null),
         "body": {

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -1,5 +1,4 @@
 import 'package:app_package_maker/app_package_maker.dart';
-import 'package:path/path.dart' as path;
 
 class MakeRPMConfig extends MakeConfig {
   String displayName;
@@ -149,7 +148,7 @@ class MakeRPMConfig extends MakeConfig {
         "Version": appVersion.toString(),
         "Name": displayName,
         "GenericName": genericName,
-        "Icon": icon != null ? path.basenameWithoutExtension(icon!) : null,
+        "Icon": appName,
         "Exec": "$appName %U",
         "Actions": actions != null && actions!.isNotEmpty
             ? actions!.join(";") + ";"

--- a/packages/flutter_distributor/bin/command_package.dart
+++ b/packages/flutter_distributor/bin/command_package.dart
@@ -10,6 +10,7 @@ class CommandPackage extends Command {
     argParser.addOption('channel', valueHelp: '');
     argParser.addOption('artifact-name', valueHelp: '');
     argParser.addFlag('skip-clean');
+    argParser.addOption('flutter-build-args', valueHelp: 'verbose,obfuscate');
     argParser.addOption('build-target', valueHelp: 'path');
     argParser.addOption('build-flavor', valueHelp: '');
     argParser.addOption('build-target-platform', valueHelp: '');
@@ -29,6 +30,7 @@ class CommandPackage extends Command {
     List<String> targets = '${argResults?['targets']}'.split(',');
     String? channel = argResults?['channel'];
     String? artifactName = argResults?['artifact-name'];
+    String? flutterBuildArgs = argResults?['flutter-build-args'];
     bool isSkipClean = argResults?.wasParsed('skip-clean') ?? false;
     Map<String, dynamic> buildArguments = {};
 
@@ -49,6 +51,22 @@ class CommandPackage extends Command {
           option.replaceAll('build-', ''),
           () => value,
         );
+      }
+
+      for (var arg in flutterBuildArgs?.split(",") ?? <String>[]) {
+        if (arg.split("=").length == 2) {
+          buildArguments.putIfAbsent(
+            arg.split("=").first,
+            () => arg.split("=").last,
+          );
+        } else if (arg.split("=").length == 1) {
+          buildArguments.putIfAbsent(
+            arg.split("=")[0],
+            () => true,
+          );
+        } else {
+          buildArguments.putIfAbsent(arg, () => true);
+        }
       }
     }
 

--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -11,7 +11,7 @@ import 'command_upgrade.dart';
 
 Future<void> main(List<String> args) async {
   FlutterDistributor distributor = FlutterDistributor();
-  await distributor.checkVersion();
+  // await distributor.checkVersion();
 
   final runner = CommandRunner('flutter_distributor', '');
   runner.argParser.addFlag(

--- a/packages/shell_executor/lib/src/shell_executor.dart
+++ b/packages/shell_executor/lib/src/shell_executor.dart
@@ -6,7 +6,8 @@ Future<ProcessResult> $(
   List<String> arguments, {
   Map<String, String>? environment,
 }) {
-  return ShellExecutor.global.exec(executable, arguments);
+  return ShellExecutor.global
+      .exec(executable, arguments, environment: environment);
 }
 
 class ShellExecutor {

--- a/website/components/MdxPage/Navbar/Navbar.tsx
+++ b/website/components/MdxPage/Navbar/Navbar.tsx
@@ -27,11 +27,13 @@ const mockdata = [
     links: [
       { label: "aab", link: "/docs/makers/aab" },
       { label: "apk", link: "/docs/makers/apk" },
+      { label: "appimage", link: "/docs/makers/appimage" },
       { label: "deb", link: "/docs/makers/deb" },
       { label: "dmg", link: "/docs/makers/dmg" },
       { label: "exe", link: "/docs/makers/exe" },
       { label: "ipa", link: "/docs/makers/ipa" },
       { label: "msix", link: "/docs/makers/msix" },
+      { label: "rpm", link: "/docs/makers/rpm" },
       { label: "zip", link: "/docs/makers/zip" },
     ],
   },


### PR DESCRIPTION
This PR adds 
- support for popular Linux packaging format [RPM](https://rpm-packaging-guide.github.io/) used in Rhel, Fedora and OpenSuse "Linux distributions"
- Docs for newly added appimage, deb and rpm package formats (en & zh)
- `--flutter-build-args` for passing flutter build arguments easily