### PR TITLE
Add documentation for custom inno setup template

### DIFF
--- a/docs/en/makers/exe.md
+++ b/docs/en/makers/exe.md
@@ -30,6 +30,15 @@ Run:
 flutter_distributor package --platform windows --targets exe
 ```
 
+## Advanced usage
+### Custom Inno Setup template
+By default, `flutter_distributor` will generate an Inno Setup configuration (`.iss`) based on an internal template on build time, and populate it with the values provided in `make_config.yaml`. If you need more control over the Inno Setup configuration, you can provide a custom template using the `script_template` option.
+
+For example:
+1. Add `script_template: inno_setup.iss` to your `make_config.yaml`
+2. Create the `inno_setup.iss` in the same directory
+3. Copy the [original template](https://github.com/leanflutter/flutter_distributor/blob/main/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_script.dart) from the source code and adjust it.
+
 ## Related Links
 
 [https://jrsoftware.org/isinfo.php](https://jrsoftware.org/isinfo.php)


### PR DESCRIPTION
Adds documentation on how to use a custom inno setup template. 

I used this for my project and it looks like [the author of this issue](https://github.com/leanflutter/flutter_distributor/issues/100) is trying to do the same.