### PR TITLE
Improve command usability (help texts, null checks, misc)

### DIFF
--- a/packages/flutter_distributor/bin/command_doctor.dart
+++ b/packages/flutter_distributor/bin/command_doctor.dart
@@ -1,9 +1,0 @@
-import 'package:args/command_runner.dart';
-
-class CommandDoctor extends Command {
-  @override
-  String get name => 'doctor';
-
-  @override
-  String get description => 'Show information about the installed tooling.';
-}

--- a/packages/flutter_distributor/bin/command_package.dart
+++ b/packages/flutter_distributor/bin/command_package.dart
@@ -1,76 +1,133 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
 
+/// Package an application bundle for a specific platform and target
+///
+/// This command wrapper defines, parses and transforms all passed arguments,
+/// so that they may be passed to `flutter_distributor`. The distributor will
+/// then build an application bundle using `flutter_app_packager`.
 class CommandPackage extends Command {
   final FlutterDistributor distributor;
 
   CommandPackage(this.distributor) {
-    argParser.addOption('platform', valueHelp: '');
-    argParser.addOption('targets', valueHelp: '');
+    argParser.addOption(
+      'platform',
+      valueHelp: [
+        'android',
+        'ios',
+        'linux',
+        'macos',
+        'windows',
+        'web',
+      ].join(','),
+      help: 'The platform to package the application for',
+    );
+
+    argParser.addOption(
+      'targets',
+      aliases: ['target'],
+      valueHelp: [
+        'apk',
+        'aab',
+        'appimage',
+        'deb',
+        'dmg',
+        'exe',
+        'ipa',
+        'msix',
+        'rpm',
+        'zip',
+      ].join(','),
+      help: 'Comma separated list of bundle types to build.',
+    );
+
     argParser.addOption('channel', valueHelp: '');
     argParser.addOption('artifact-name', valueHelp: '');
-    argParser.addFlag('skip-clean');
-    argParser.addOption('flutter-build-args', valueHelp: 'verbose,obfuscate');
-    argParser.addOption('build-target', valueHelp: 'path');
-    argParser.addOption('build-flavor', valueHelp: '');
-    argParser.addOption('build-target-platform', valueHelp: '');
-    argParser.addOption('build-export-options-plist', valueHelp: '');
-    argParser.addMultiOption('build-dart-define', valueHelp: 'foo=bar');
+
+    argParser.addFlag(
+      'skip-clean',
+      help: 'Whether or not to skip \'flutter clean\' before packaging.',
+    );
+
+    argParser.addOption(
+      'flutter-build-args',
+      valueHelp: 'verbose,obfuscate',
+      help: 'Arguments to pass directly to flutter build',
+    );
+
+    argParser.addOption(
+      'build-target',
+      valueHelp: 'path',
+      help: 'The --target argument passed to \'flutter build\'',
+    );
+
+    argParser.addOption(
+      'build-flavor',
+      valueHelp: '',
+      help: 'The --flavor argument passed to \'flutter build\'',
+    );
+
+    argParser.addOption(
+      'build-target-platform',
+      valueHelp: '',
+      help: 'The --target-platform argument passed to \'flutter build\'',
+    );
+
+    argParser.addOption(
+      'build-export-options-plist',
+      valueHelp: '',
+      help: 'The --export-options-plist argument passed \'flutter build\'',
+    );
+
+    argParser.addMultiOption(
+      'build-dart-define',
+      valueHelp: 'foo=bar',
+      help: [
+        'The --dart-define argument(s) passed to \'flutter build\'',
+        'You may add multiple \'--build-dart-define key=value\' pairs'
+      ].join('\n'),
+    );
   }
 
   @override
   String get name => 'package';
 
   @override
-  String get description => 'Package the current Flutter application';
+  String get description => [
+        'Package the current Flutter application',
+        '',
+        'Options named --build-* are passed to \'flutter build\' as is',
+        'Please consult the \'flutter build\' CLI help for more informations.'
+      ].join('\n');
 
   @override
   Future run() async {
-    String platform = argResults?['platform'];
-    List<String> targets = '${argResults?['targets']}'.split(',');
-    String? channel = argResults?['channel'];
-    String? artifactName = argResults?['artifact-name'];
-    String? flutterBuildArgs = argResults?['flutter-build-args'];
-    bool isSkipClean = argResults?.wasParsed('skip-clean') ?? false;
-    Map<String, dynamic> buildArguments = {};
+    final String? platform = argResults?['platform'];
+    final List<String> targets = '${argResults?['targets'] ?? ''}'
+        .split(',')
+        .where((e) => e.isNotEmpty)
+        .toList();
+    final String? channel = argResults?['channel'];
+    final String? artifactName = argResults?['artifact-name'];
+    final String? flutterBuildArgs = argResults?['flutter-build-args'];
+    final bool isSkipClean = argResults?.wasParsed('skip-clean') ?? false;
+    final Map<String, dynamic> buildArguments =
+        _generateBuildArgs(flutterBuildArgs);
 
-    if (argResults?.options != null) {
-      for (var option in argResults!.options) {
-        if (!option.startsWith('build-')) continue;
-        dynamic value = argResults?[option];
-
-        if (value is List) {
-          value = Map.fromIterable(
-            value,
-            key: (e) => e.split('=')[0],
-            value: (e) => e.split('=')[1],
-          );
-        }
-
-        buildArguments.putIfAbsent(
-          option.replaceAll('build-', ''),
-          () => value,
-        );
-      }
-
-      for (var arg in flutterBuildArgs?.split(",") ?? <String>[]) {
-        if (arg.split("=").length == 2) {
-          buildArguments.putIfAbsent(
-            arg.split("=").first,
-            () => arg.split("=").last,
-          );
-        } else if (arg.split("=").length == 1) {
-          buildArguments.putIfAbsent(
-            arg.split("=")[0],
-            () => true,
-          );
-        } else {
-          buildArguments.putIfAbsent(arg, () => true);
-        }
-      }
+    // At least `platform` and one `targets` is required for flutter build
+    if (platform == null) {
+      print('\nThe \'platform\' options is mandatory! Aborting.');
+      exit(1);
     }
 
-    await distributor.package(
+    if (targets.isEmpty) {
+      print('\nAt least one \'target\' must be specified! Aborting.');
+      exit(1);
+    }
+
+    return distributor.package(
       platform,
       targets,
       channel: channel,
@@ -78,5 +135,47 @@ class CommandPackage extends Command {
       cleanBeforeBuild: !isSkipClean,
       buildArguments: buildArguments,
     );
+  }
+
+  Map<String, dynamic> _generateBuildArgs(String? flutterBuildArgs) {
+    Map<String, dynamic> buildArguments = {};
+
+    if (argResults?.options == null) return buildArguments;
+
+    for (var option in argResults!.options) {
+      if (!option.startsWith('build-')) continue;
+      dynamic value = argResults?[option];
+
+      if (value is List) {
+        value = Map.fromIterable(
+          value,
+          key: (e) => e.split('=')[0],
+          value: (e) => e.split('=')[1],
+        );
+      }
+
+      buildArguments.putIfAbsent(
+        option.replaceAll('build-', ''),
+        () => value,
+      );
+    }
+
+    for (var arg in flutterBuildArgs?.split(",") ?? <String>[]) {
+      if (arg.split("=").length == 2) {
+        buildArguments.putIfAbsent(
+          arg.split("=").first,
+          () => arg.split("=").last,
+        );
+      } else if (arg.split("=").length == 1) {
+        buildArguments.putIfAbsent(
+          arg.split("=")[0],
+          () => true,
+        );
+      } else {
+        buildArguments.putIfAbsent(arg, () => true);
+      }
+    }
+
+    return buildArguments;
   }
 }

--- a/packages/flutter_distributor/bin/command_package.dart
+++ b/packages/flutter_distributor/bin/command_package.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
+import 'package:flutter_distributor/src/extensions/extensions.dart';
 
 /// Package an application bundle for a specific platform and target
 ///
@@ -118,12 +119,12 @@ class CommandPackage extends Command {
 
     // At least `platform` and one `targets` is required for flutter build
     if (platform == null) {
-      print('\nThe \'platform\' options is mandatory! Aborting.');
+      print('\nThe \'platform\' options is mandatory!'.red(bold: true));
       exit(1);
     }
 
     if (targets.isEmpty) {
-      print('\nAt least one \'target\' must be specified! Aborting.');
+      print('\nAt least one \'target\' must be specified!'.red(bold: true));
       exit(1);
     }
 

--- a/packages/flutter_distributor/bin/command_publish.dart
+++ b/packages/flutter_distributor/bin/command_publish.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
+import 'package:flutter_distributor/src/extensions/extensions.dart';
 
 /// Publish an application to a third party provider
 ///
@@ -154,19 +155,20 @@ class CommandPublish extends Command {
   @override
   Future run() async {
     String? path = argResults?['path'];
-    List<String> targets = '${argResults?['targets']}'
+    List<String> targets = '${argResults?['targets'] ?? ''}'
         .split(',')
         .where((t) => t.isNotEmpty)
         .toList();
 
     // At least `path` and one `targets` is required for flutter build
     if (path == null) {
-      print('\nThe \'path\' options is mandatory! Aborting.');
+      print('\nThe \'path\' options is mandatory!'.red(bold: true));
       exit(1);
     }
 
+    print(targets);
     if (targets.isEmpty) {
-      print('\nAt least one \'target\' must be specified! Aborting.');
+      print('\nAt least one \'target\' must be specified!'.red(bold: true));
       exit(1);
     }
 

--- a/packages/flutter_distributor/bin/command_publish.dart
+++ b/packages/flutter_distributor/bin/command_publish.dart
@@ -3,34 +3,141 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
 
+/// Publish an application to a third party provider
+///
+/// This command wrapper defines, parses and transforms all passed arguments,
+/// so that they may be passed to `flutter_distributor`. The distributor will
+/// then publish an application bundle using `flutter_app_publisher`.
 class CommandPublish extends Command {
   final FlutterDistributor distributor;
 
   CommandPublish(this.distributor) {
-    argParser.addOption('path', valueHelp: '');
-    argParser.addOption('targets', valueHelp: '');
+    argParser.addOption(
+      'path',
+      valueHelp: '',
+      help: 'The path to the application bundle to publish.',
+    );
+
+    argParser.addOption(
+      'targets',
+      aliases: ['target'],
+      valueHelp: [
+        'appcenter',
+        'appstore',
+        'fir',
+        'firebase',
+        'github',
+        'playstore',
+        'pgyer',
+        'qiniu',
+      ].join(','),
+      help: 'The target provider(s) to publish to.',
+    );
+
     // AppCenter
     argParser.addSeparator('appcenter');
-    argParser.addOption('appcenter-owner-name', valueHelp: '');
-    argParser.addOption('appcenter-app-name', valueHelp: '');
-    argParser.addOption('appcenter-distribution-group', valueHelp: '');
+
+    argParser.addOption(
+      'appcenter-owner-name',
+      valueHelp: '',
+      help: 'The owner name for appcenter.',
+    );
+
+    argParser.addOption(
+      'appcenter-app-name',
+      valueHelp: '',
+      help: 'The app name for appcenter.',
+    );
+
+    argParser.addOption(
+      'appcenter-distribution-group',
+      valueHelp: '',
+      help: 'The distribution group for appcenter.',
+    );
+
     // Firebase
     argParser.addSeparator('firebase');
-    argParser.addOption('firebase-app', valueHelp: '');
-    argParser.addOption('firebase-release-notes', valueHelp: '');
-    argParser.addOption('firebase-release-notes-file', valueHelp: '');
-    argParser.addOption('firebase-testers', valueHelp: '');
-    argParser.addOption('firebase-testers-file', valueHelp: '');
-    argParser.addOption('firebase-groups', valueHelp: '');
-    argParser.addOption('firebase-groups-file', valueHelp: '');
+
+    argParser.addOption(
+      'firebase-app',
+      valueHelp: '',
+      help: [
+        'The unique ID of the application on Firebase.',
+        'This is NOT your bundle identifier',
+      ].join('\n'),
+    );
+
+    argParser.addOption(
+      'firebase-release-notes',
+      valueHelp: '',
+      help: 'The release notes for the published application.',
+    );
+
+    argParser.addOption(
+      'firebase-release-notes-file',
+      valueHelp: '',
+      help: [
+        'The path of a file containing the release notes',
+        'This is a more extensive alternative to firebase-release-notes',
+      ].join('\n'),
+    );
+
+    argParser.addOption(
+      'firebase-testers',
+      valueHelp: '',
+      help:
+          'The testers that will be notified about the published application.',
+    );
+
+    argParser.addOption(
+      'firebase-testers-file',
+      valueHelp: '',
+      help: [
+        'The path of a file containing testers that will be notified',
+        'This is a more extensive alternative to firebase-testers',
+      ].join('\n'),
+    );
+
+    argParser.addOption(
+      'firebase-groups',
+      valueHelp: '',
+      help: 'The groups that will be notified about the published application.',
+    );
+
+    argParser.addOption(
+      'firebase-groups-file',
+      valueHelp: '',
+      help: [
+        'The path of a file containing groups that will be notified',
+        'This is a more extensive alternative to firebase-groups',
+      ].join('\n'),
+    );
+
     // Github
     argParser.addSeparator('github');
-    argParser.addOption('github-repo-owner', valueHelp: '');
-    argParser.addOption('github-repo-name', valueHelp: '');
-    argParser.addOption('github-release-title', valueHelp: '');
+
+    argParser.addOption(
+      'github-repo-owner',
+      valueHelp: '',
+      help: 'The name of the target GitHub repository wner (namespace)',
+    );
+
+    argParser.addOption(
+      'github-repo-name',
+      valueHelp: '',
+      help: 'The name of the target GitHub repository',
+    );
+
+    argParser.addOption(
+      'github-release-title',
+      valueHelp: '',
+      help: 'The title of the new release on GitHub',
+    );
+
     // PlayStore
     argParser.addSeparator('playstore');
     argParser.addOption('playstore-package-name', valueHelp: '');
+
     // Qiniu
     argParser.addSeparator('qiniu');
     argParser.addOption('qiniu-bucket', valueHelp: '');
@@ -46,8 +153,31 @@ class CommandPublish extends Command {
 
   @override
   Future run() async {
-    String path = argResults?['path'];
-    List<String> targets = '${argResults?['targets']}'.split(',');
+    String? path = argResults?['path'];
+    List<String> targets = '${argResults?['targets']}'
+        .split(',')
+        .where((t) => t.isNotEmpty)
+        .toList();
+
+    // At least `path` and one `targets` is required for flutter build
+    if (path == null) {
+      print('\nThe \'path\' options is mandatory! Aborting.');
+      exit(1);
+    }
+
+    if (targets.isEmpty) {
+      print('\nAt least one \'target\' must be specified! Aborting.');
+      exit(1);
+    }
+
+    // Required parameters for firebase
+    if (targets.contains('firebase')) {
+      if (argResults?['firebase-app'] == null) {
+        print('\nFirebase app identifier is required for target \'firebase\'');
+        exit(1);
+      }
+    }
+
     Map<String, String?> publishArguments = {
       'appcenter-owner-name': argResults?['appcenter-owner-name'],
       'appcenter-app-name': argResults?['appcenter-app-name'],
@@ -69,7 +199,7 @@ class CommandPublish extends Command {
       'qiniu-savekey-prefix': argResults?['qiniu-savekey-prefix'],
     }..removeWhere((key, value) => value == null);
 
-    await distributor.publish(
+    return distributor.publish(
       File(path),
       targets,
       publishArguments: publishArguments,

--- a/packages/flutter_distributor/bin/command_release.dart
+++ b/packages/flutter_distributor/bin/command_release.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
+import 'package:flutter_distributor/src/extensions/extensions.dart';
 
 /// Release (package and publish) an application based on the config
 ///
@@ -61,7 +62,7 @@ class CommandRelease extends Command {
 
     // At least `name` must be passed to select a release
     if (name == null) {
-      print('\nThe \'name\' options is mandatory! Aborting.');
+      print('\nThe \'name\' options is mandatory!'.red(bold: true));
       exit(1);
     }
 

--- a/packages/flutter_distributor/bin/command_release.dart
+++ b/packages/flutter_distributor/bin/command_release.dart
@@ -1,14 +1,43 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
 
+/// Release (package and publish) an application based on the config
+///
+/// This command wrapper defines, parses and transforms all passed arguments,
+/// so that they may be passed to `flutter_distributor`. The distributor will
+/// then use the `distribute_options.yaml` file in the Flutter project root
+/// to run a release with one or multiple release jobs.
+///
+/// Each release job will package and optionally also publish the application
+/// based on the configuration on `distribute_options.yaml`.
 class CommandRelease extends Command {
   final FlutterDistributor distributor;
 
   CommandRelease(this.distributor) {
-    argParser.addOption('name', valueHelp: '');
-    argParser.addOption('jobs', valueHelp: '');
-    argParser.addOption('skip-jobs', valueHelp: '');
-    argParser.addFlag('skip-clean');
+    argParser.addOption(
+      'name',
+      valueHelp: '',
+      help: 'The name of the release to run.',
+    );
+
+    argParser.addOption(
+      'jobs',
+      valueHelp: '',
+      help: 'Comma-separated list of jobs to run for the specified release.',
+    );
+
+    argParser.addOption(
+      'skip-jobs',
+      valueHelp: '',
+      help: 'Comma-separated list of jobs to skip for the specified release.',
+    );
+
+    argParser.addFlag(
+      'skip-clean',
+      help: 'Whether or not to skip \'flutter clean\' before packaging.',
+    );
   }
 
   @override
@@ -19,7 +48,7 @@ class CommandRelease extends Command {
 
   @override
   Future run() async {
-    String name = argResults?['name'] ?? '';
+    String? name = argResults?['name'] ?? '';
     List<String> jobNameList = (argResults?['jobs'] ?? '')
         .split(',')
         .where((String e) => e.isNotEmpty)
@@ -30,7 +59,13 @@ class CommandRelease extends Command {
         .toList();
     bool isSkipClean = argResults?.wasParsed('skip-clean') ?? false;
 
-    await distributor.release(
+    // At least `name` must be passed to select a release
+    if (name == null) {
+      print('\nThe \'name\' options is mandatory! Aborting.');
+      exit(1);
+    }
+
+    return distributor.release(
       name,
       jobNameList: jobNameList,
       skipJobNameList: skipJobNameList,

--- a/packages/flutter_distributor/bin/command_upgrade.dart
+++ b/packages/flutter_distributor/bin/command_upgrade.dart
@@ -1,6 +1,7 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
 
+/// Upgrade flutter_distributor to the latest version
 class CommandUpgrade extends Command {
   final FlutterDistributor distributor;
 

--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -10,9 +10,12 @@ import 'command_upgrade.dart';
 
 Future<void> main(List<String> args) async {
   FlutterDistributor distributor = FlutterDistributor();
-  // await distributor.checkVersion();
+
+  // Check version of flutter_distributor on every run
+  await distributor.checkVersion();
 
   final runner = CommandRunner('flutter_distributor', '');
+
   runner.argParser.addFlag(
     'version',
     negatable: false,

--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -3,7 +3,6 @@ import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
 import 'package:flutter_distributor/src/utils/logger.dart';
 
-// import 'command_doctor.dart';
 import 'command_package.dart';
 import 'command_publish.dart';
 import 'command_release.dart';
@@ -20,7 +19,6 @@ Future<void> main(List<String> args) async {
     help: 'Reports the version of this tool.',
   );
 
-  // runner.addCommand(CommandDoctor());
   runner.addCommand(CommandPackage(distributor));
   runner.addCommand(CommandPublish(distributor));
   runner.addCommand(CommandRelease(distributor));

--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -36,5 +36,5 @@ Future<void> main(List<String> args) async {
     }
   }
 
-  await runner.runCommand(argResults);
+  return runner.runCommand(argResults);
 }

--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -339,13 +339,14 @@ class FlutterDistributor {
       logger.info(
         'RELEASE SUCCESSFUL in ${time.elapsed.inSeconds}s'.green(bold: true),
       );
-    } catch (error) {
+    } catch (error, stacktrace) {
       time.stop();
       logger.info('');
       logger.severe(
         [
           'RELEASE FAILED in ${time.elapsed.inSeconds}s'.red(bold: true),
           error.toString().red(),
+          stacktrace,
         ].join('\n'),
       );
     }

--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -343,7 +343,10 @@ class FlutterDistributor {
       time.stop();
       logger.info('');
       logger.severe(
-        'RELEASE FAILED in ${time.elapsed.inSeconds}s'.red(bold: true),
+        [
+          'RELEASE FAILED in ${time.elapsed.inSeconds}s'.red(bold: true),
+          error.toString().red(),
+        ].join('\n'),
       );
     }
     return Future.value();


### PR DESCRIPTION
This is a larger set of changes adding the following:
* Help descriptions and values for all command arguments (except some I did not know yet).
* Proper checking of required parameters for a command with error messages.
* Show error output when `release` fails. Currently, it does not output **any** information.
* Fix auto-update, has been commented out by a recent PR (accidentally, I assume?)

Breaking changes:
* Commands now return exit code `1` instead of `0` when a required parameter is missing

There is still some output being lost when using `release` for multiple jobs. @lijy91 if that's ok for you, I'd like to add (in another PR) a `--verbose` / `-v` flag to `flutter_distributor` that automatically passes `--verbose` to flutter commands (where possible) and outputs more information in case of success (results of every job) exceptions (stack trace)