### PR TITLE
Add possibility to customize shell commands with env

### DIFF
--- a/packages/shell_executor/lib/src/shell_customizer.dart
+++ b/packages/shell_executor/lib/src/shell_customizer.dart
@@ -1,0 +1,73 @@
+import 'dart:io' show Platform;
+
+/// Customizer for shell commands to overwrite executables from the env.
+///
+/// This customizer allows a user to overwrite the executable that will be used
+/// for running a command with environment variables.
+///
+/// This can be useful if `shell_executor` is used for running generated
+/// commands, for example from `flutter_distributor`, but the user wants to
+/// use a different executable. (e.g. use `fvm flutter` instead of `flutter`)
+class ShellCustomizer {
+  /// Customize a command and its arguments depending on the environment
+  ///
+  /// This will look for an environment variable in the following format:
+  ///   `SHELL_EXECUTOR_???_COMMAND`
+  /// where `???` equals the `executable` passed to this function. If this
+  /// variable is present, its contents are used instead of the original
+  /// executable.
+  ///
+  /// It is possible to replace an `executable` with a multi-part command by
+  /// using `SHELL_EXECUTOR_FLUTTER_COMMAND="fvm flutter"`.
+  /// Please note that this does not allow for quoted strings with spaces in
+  /// the replacement command but this tradeoff should work in most use cases.
+  ///
+  /// For example, running `'flutter', ['clean']` with the environment
+  /// `SHELL_EXECUTOR_FLUTTER_COMMAND="butter"` will instead run
+  /// `'butter', ['clean']`
+  ///
+  /// Running `'flutter', ['clean']` with the environment
+  /// `SHELL_EXECUTOR_FLUTTER_COMMAND="fvm flutter"` will instead run
+  /// `'fvm', ['flutter', 'clean']`
+  ///
+  /// Parameters:
+  ///  * executable - The executable to run
+  ///  * arguments - The arguments to pass to the executable
+  ///
+  /// Returns:
+  ///   A `CustomizedShellCommand` containing the modified executable and
+  ///   arguments (or the original values if no env variable was present).
+  static CustomizedShellCommand customizeCommand(
+    String executable,
+    List<String> arguments,
+  ) {
+    final exeEnvName = executable.toUpperCase();
+    final envVarName = 'SHELL_EXECUTOR_${exeEnvName}_COMMAND';
+    final customCommand = Platform.environment[envVarName];
+
+    if (customCommand != null && customCommand is String) {
+      final commandParts = customCommand.split(" ");
+
+      if (commandParts.length >= 1) {
+        executable = commandParts[0];
+      }
+
+      if (commandParts.length >= 2) {
+        arguments = [...commandParts, ...arguments];
+        arguments.removeAt(0);
+      }
+    }
+
+    return CustomizedShellCommand(executable, arguments);
+  }
+}
+
+class CustomizedShellCommand {
+  /// The executable to run
+  String executable;
+
+  /// List of arguments to pass to the executable
+  List<String> arguments;
+
+  CustomizedShellCommand(this.executable, this.arguments);
+}

--- a/packages/shell_executor/lib/src/shell_executor.dart
+++ b/packages/shell_executor/lib/src/shell_executor.dart
@@ -1,13 +1,20 @@
 import 'dart:convert';
 import 'dart:io';
 
+import './shell_customizer.dart';
+
 Future<ProcessResult> $(
   String executable,
   List<String> arguments, {
   Map<String, String>? environment,
 }) {
-  return ShellExecutor.global
-      .exec(executable, arguments, environment: environment);
+    final command = ShellCustomizer.customizeCommand(executable, arguments);
+
+    return ShellExecutor.global.exec(
+      command.executable,
+      command.arguments,
+      environment: environment,
+    ); 
 }
 
 class ShellExecutor {


### PR DESCRIPTION
This is a suggestion to solve [this issue](https://github.com/leanflutter/flutter_distributor/issues/107) by allowing users to overwrite executables in `shell_executor` from the environment. 

**In short:**    
Set `SHELL_EXECUTOR_..._COMMAND` to overwrite the executable for a command. E.g. `SHELL_EXECUTOR_FLUTTER_COMMAND=/usr/bin/flutter2`

**Example when using with `flutter_distributor`:**
```
flutter_distributor package --platform android --targets=apk                           
$ flutter clean
$ flutter build apk --dart-define FLUTTER_BUILD_NAME=1.2.8 --dart-define FLUTTER_BUILD_NUMBER=1365

SHELL_EXECUTOR_FLUTTER_COMMAND="fvm flutter" flutter_distributor package --platform android --targets=apk
$ fvm flutter clean
$ fvm flutter build apk --dart-define FLUTTER_BUILD_NAME=1.2.8 --dart-define FLUTTER_BUILD_NUMBER=1365

```