### PR TITLE
[AppImage] Use appimagetool  to bundle AppImage

### DIFF
--- a/examples/hello_world/linux/packaging/appimage/make_config.yaml
+++ b/examples/hello_world/linux/packaging/appimage/make_config.yaml
@@ -1,17 +1,39 @@
-appId: org.leanflutter.examples.hello_world
-# relative path to the application's icon
+display_name: Hello World
+
 icon: assets/logo.png
 
-script:
-  - echo 'Running a Script'
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
 
+generic_name: Cool Application
+
+actions:
+  - name: Say Hi
+    label: say-hi
+    arguments:
+      - --say
+      - hi
+  - name: Say Bye
+    label: say-bye
+    arguments:
+      - --say
+      - bye
+
+categories:
+  - Music
+
+startup_notify: true
+
+# You can specify the shared libraries that you want to bundle with your app
+#
+# flutter_distribute automatically detects the shared libraries that your app
+# depends on, but you can also specify them manually here.
+# 
+# The following example shows how to bundle the libcurl library with your app.
+#
+# include:
+#   - libcurl.so.4
 include: []
-exclude: []
-# its true by default
-default_excludes: true
-
-files:
-  include: []
-  exclude: []
-  # its true by default
-  default_excludes: true

--- a/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
@@ -3,191 +3,103 @@
 import 'dart:io';
 
 import 'package:app_package_maker/app_package_maker.dart';
-import 'package:path/path.dart' as path;
 
-/// this how the config should look like
-/// appId: lol.itsanapp.question
-// # relative path to icon
-/// icon: assets/logo.png
-// # this is the default script command
-/// script:
-///   - rm -rf build/AppDir || true
-///   - cp -r build/linux/x64/release/bundle AppDir
-///   - mkdir -p build/AppDir/usr/share/icons/hicolor/64x64/apps/
-///   - cp assets/spotube-logo.png build/AppDir/usr/share/icons/hicolor/64x64/apps/
-// # name of [apt] packages that should be included
-/// include:
-///   - libkeybinder-3.0-0
-/// exclude:
-// # by default following dependencies will be excluded
-///   - libx11-6
-///   - libgtk-3-0
-///   - libglib2.0-0
-///   - libc6
-// # toggle for excluding those flutter system dependencies by default
-// # @default (true)
-/// default_excludes: true
-/// files:
-// # file include/exclude
-///   include: []
-// # by default these will be excluded
-///   exclude:
-///     - usr/share/man
-///     - usr/share/doc/*/README.*
-///     - usr/share/doc/*/changelog.*
-///     - usr/share/doc/*/NEWS.*
-///   - usr/share/doc/*/TODO.*
-//    # toggle for excluding those directories by default
-//    # @default (true)
-///   default_excludes: true
-
-const defaultScript = [
-  'rm -rf AppDir || true',
-  'cp -r build/linux/x64/release/bundle AppDir',
-  'mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/',
-];
-
-const defaultExclude = [
-  'libx11-6',
-  'libgtk-3-0',
-  'libglib2.0-0',
-  'libc6',
-];
-
-const defaultExcludeFiles = [
-  'usr/share/man',
-  'usr/share/doc/*/README.*',
-  'usr/share/doc/*/changelog.*',
-  'usr/share/doc/*/NEWS.*',
-];
-
-class MakeAppImageConfig extends MakeConfig {
-  MakeAppImageConfig({
-    List<String> script = const [],
-    List<String> exclude = const [],
-    List<String> exclude_files = const [],
-    required this.appId,
-    required this.include,
-    required this.include_files,
-    this.icon,
-    this.default_excludes = true,
-    this.default_excludes_files = true,
-  })  : _script = script,
-        _exclude = exclude,
-        _exclude_files = exclude_files;
-
-  factory MakeAppImageConfig.fromJson(Map<String, dynamic> map) {
-    return MakeAppImageConfig(
-      appId: map['appId'],
-      icon: map['icon'],
-      script: List.castFrom<dynamic, String>(map['script'] ?? []),
-      include: List.castFrom<dynamic, String>(map['include'] ?? []),
-      exclude: List.castFrom<dynamic, String>(map['exclude'] ?? []),
-      default_excludes: map['default_excludes'] ?? true,
-      include_files:
-          List.castFrom<dynamic, String>(map['files']?['include'] ?? []),
-      exclude_files:
-          List.castFrom<dynamic, String>(map['files']?['exclude'] ?? []),
-      default_excludes_files: map['files']?['default_excludes'] ?? false,
+class AppImageAction {
+  AppImageAction({
+    required this.label,
+    required this.name,
+    required this.arguments,
+  });
+  factory AppImageAction.fromJson(Map<String, dynamic> map) {
+    return AppImageAction(
+      label: map['label'] as String,
+      name: map['name'] as String,
+      arguments: (map['arguments'] as List<dynamic>).cast<String>(),
     );
   }
-
-  String appId;
-  String? icon;
-  List<String> _script;
-  List<String> include;
-  List<String> _exclude;
-  bool default_excludes;
-  List<String> include_files;
-  List<String> _exclude_files;
-  bool default_excludes_files;
-
-  List<String> get script => [
-        ...defaultScript,
-        if (icon != null) 'cp $icon AppDir/usr/share/icons/hicolor/',
-        ..._script
-      ];
-  List<String> get exclude => [
-        ...(default_excludes ? defaultExclude : []),
-        ..._exclude,
-      ];
-  List<String> get exclude_files => [
-        ...(default_excludes_files ? defaultExcludeFiles : []),
-        ..._exclude_files,
-      ];
+  String label;
+  String name;
+  List<String> arguments;
 
   Map<String, dynamic> toJson() {
     return {
-      'version': 1,
-      'script': script,
-      'AppDir': {
-        'path': 'AppDir',
-        'app_info': {
-          'id': appId,
-          if (icon != null) 'icon': path.basenameWithoutExtension(icon!),
-          'name': appName,
-          'version': appVersion.toString(),
-          'exec': appName,
-          'exec_args': '\$@',
-        },
-        'apt': {
-          'arch': 'amd64',
-          'allow_unauthenticated': true,
-          'sources': [
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute main restricted'
-            },
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute-updates main restricted'
-            },
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute universe'
-            },
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute-updates universe'
-            },
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute multiverse'
-            },
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute-updates multiverse'
-            },
-            {
-              'sourceline':
-                  'deb http://archive.ubuntu.com/ubuntu/ hirsute-backports main           restricted universe multiverse'
-            },
-            {
-              'sourceline':
-                  'deb http://security.ubuntu.com/ubuntu hirsute-security main restricted'
-            },
-            {
-              'sourceline':
-                  'deb http://security.ubuntu.com/ubuntu hirsute-security universe'
-            },
-            {
-              'sourceline':
-                  'deb http://security.ubuntu.com/ubuntu hirsute-security multiverse'
-            },
-          ],
-          'include': include,
-          'exclude': exclude,
-        },
-        'files': {
-          'include': include_files,
-          'exclude': exclude_files,
-        },
-      },
-      'AppImage': {
-        'arch': 'x86_64',
-        'update-information': 'guess',
-      }
-    }..removeWhere((key, value) => value == null);
+      'label': label,
+      'name': name,
+      'arguments': arguments,
+    };
+  }
+}
+
+class MakeAppImageConfig extends MakeConfig {
+  MakeAppImageConfig({
+    required this.displayName,
+    required this.icon,
+    this.keywords = const [],
+    this.categories = const [],
+    this.actions = const [],
+    this.include = const [],
+    this.startupNotify = true,
+    this.genericName = 'A Flutter Application',
+  });
+  factory MakeAppImageConfig.fromJson(Map<String, dynamic> map) {
+    return MakeAppImageConfig(
+      displayName: map['display_name'] as String,
+      icon: map['icon'] as String,
+      include: (map['include'] as List<dynamic>).cast<String>(),
+      keywords: (map['keywords'] as List<dynamic>).cast<String>(),
+      categories: (map['categories'] as List<dynamic>).cast<String>(),
+      startupNotify: map['startup_notify'] as bool,
+      genericName: map['generic_name'] as String,
+      actions: (map['actions'] as List? ?? [])
+          .map((e) => AppImageAction.fromJson(
+              (Map.castFrom<dynamic, dynamic, String, dynamic>(e))))
+          .toList(),
+    );
+  }
+
+  final String icon;
+  final List<String> keywords;
+  final List<String> categories;
+  final List<AppImageAction> actions;
+  final bool startupNotify;
+  final String genericName;
+  final String displayName;
+  final List<String> include;
+
+  String get desktopFileContent {
+    final fields = {
+      'Name': displayName,
+      'GenericName': genericName,
+      'Exec': 'LD_LIBRARY_PATH=usr/lib $appName %u',
+      'Icon': appName,
+      'Type': 'Application',
+      'StartupNotify': startupNotify ? 'true' : 'false',
+      if (categories.isNotEmpty) 'Categories': categories.join(';'),
+      if (keywords.isNotEmpty) 'Keywords': keywords.join(';'),
+      if (this.actions.isNotEmpty)
+        'Actions': this.actions.map((e) => e.label).join(';'),
+    }.entries.map((e) => '${e.key}=${e.value}').join('\n');
+
+    final actions = this.actions.map((action) {
+      final fields = {
+        'Name': action.name,
+        'Exec':
+            'LD_LIBRARY_PATH=usr/lib $appName ${action.arguments.join(' ')} %u',
+      };
+      return '[Desktop Action ${action.label}]\n${fields.entries.map((e) => '${e.key}=${e.value}').join('\n')}';
+    }).join('\n\n');
+
+    return '[Desktop Entry]\n$fields\n\n$actions';
+  }
+
+  String get appRunContent {
+    return '''
+#!/bin/bash
+
+cd "\$(dirname "\$0")"
+export LD_LIBRARY_PATH=usr/lib
+exec ./$appName
+''';
   }
 }
 


### PR DESCRIPTION
This PR,
- adds ability to create AppImage in any distro (Even on Gentoo) 
- removes dependence on `appimage-builder` which is troublesome to install
- uses official [`appimagetool`](https://github.com/AppImage/AppImageKit/) which is well maintained, smaller and easy to install
- more configurable properties in `make_config.yaml`

flutter_distributor can now smartly detect __required__ shared object dependencies of a flutter app and copies those shared_objects to AppImage bundle, so no more dependency mess