### PR TITLE
[rpm] fix lib/*.so rpath before packaging

### DIFF
--- a/docs/en/makers/rpm.md
+++ b/docs/en/makers/rpm.md
@@ -4,13 +4,14 @@ title: RPM
 
 ## Requires
 
+- [patchelf](https://github.com/NixOS/patchelf)
 - [rpmbuild](https://rpm-packaging-guide.github.io/#prerequisites)
 
-Install `rpmbuild`:
+Install requirements:
 
-- Debian/Ubuntu: `apt install rpm`
-- Fedora: `dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools`
-- Arch: `yay -S rpmdevtools` or `pamac install rpmdevtools`
+- Debian/Ubuntu: `apt install rpm patchelf`
+- Fedora: `dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools patchelf`
+- Arch: `yay -S rpmdevtools patchelf` or `pamac install rpmdevtools patchelf`
 
 ## Usage
 

--- a/docs/zh/makers/rpm.md
+++ b/docs/zh/makers/rpm.md
@@ -4,13 +4,14 @@ title: RPM
 
 ## 必要条件
 
+- [patchelf](https://github.com/NixOS/patchelf)
 - [rpmbuild](https://rpm-packaging-guide.github.io/#prerequisites)
 
-安装 `rpmbuild`:
+安装要求：
 
-- Debian/Ubuntu: `apt install rpm`
-- Fedora: `dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools`
-- Arch: `yay -S rpmdevtools` or `pamac install rpmdevtools`
+- Debian/Ubuntu: `apt install rpm patchelf`
+- Fedora: `dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools patchelf`
+- Arch: `yay -S rpmdevtools patchelf` or `pamac install rpmdevtools patchelf`
 
 ## 用法
 

--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -97,7 +97,7 @@ class AppPackageMakerRPM extends AppPackageMaker {
     final libFiles = Directory(path.join(buildRoot, 'lib')).listSync();
     for (final file in libFiles) {
       if (file is! File) continue;
-      if (!file.path.endsWith('_plugin.so')) continue;
+      if (!file.path.endsWith('.so')) continue;
       // check if points to /home dir
       final processResult = await $(
         'patchelf',

--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -91,6 +91,33 @@ class AppPackageMakerRPM extends AppPackageMaker {
       );
     }
 
+    // fix lib_*_plugin.so rpath
+    //
+    // more details: https://github.com/flutter/flutter/issues/65400
+    final libFiles = Directory(path.join(buildRoot, 'lib')).listSync();
+    for (final file in libFiles) {
+      if (file is! File) continue;
+      if (!file.path.endsWith('_plugin.so')) continue;
+      // check if points to /home dir
+      final processResult = await $(
+        'patchelf',
+        [
+          '--print-rpath',
+          file.path,
+        ],
+      );
+      if (processResult.stdout.toString().contains('/home')) {
+        await $(
+          'patchelf',
+          [
+            '--set-rpath',
+            '\$ORIGIN',
+            file.path,
+          ],
+        );
+      }
+    }
+
     final iconFile = makeConfig.icon != null
         ? File(path.join(Directory.current.path, makeConfig.icon!))
         : null;
@@ -129,7 +156,7 @@ class AppPackageMakerRPM extends AppPackageMaker {
         '-bb',
         specFile.path,
       ],
-      environment: {'QA_RPATHS': (0x0001 | 0x0002 | 0x0010).toString()},
+      environment: {'QA_RPATHS': (0x0001 | 0x0010).toString()},
     );
 
     if (processResult.exitCode != 0) {


### PR DESCRIPTION
Currently, due to flutter's way of using CMake, creates shared objects (.so) with absolute rpath(s) so when a shared object depends on a system shared object `rpmbuild` complains about .so files containing invalid rpath(s)
https://github.com/flutter/flutter/issues/65400

Setting rpath to `$ORIGIN` for those shared objects is a workaround for this issue. And this PR applies that workaround
