### PR TITLE
fix: fix make_dmg_config lost <window> specification

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/dmg/make_dmg_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/dmg/make_dmg_config.dart
@@ -57,8 +57,10 @@ class DmgWindow {
 
   factory DmgWindow.fromJson(Map<String, dynamic> json) {
     return DmgWindow(
-      position: DmgWindowPosition.fromJson(json['position']),
-      size: DmgWindowSize.fromJson(json['size']),
+      position: json['position'] != null
+          ? DmgWindowPosition.fromJson(json['position'])
+          : null,
+      size: json['size'] != null ? DmgWindowSize.fromJson(json['size']) : null,
     );
   }
   final DmgWindowPosition? position;
@@ -140,6 +142,7 @@ class MakeDmgConfig extends MakeConfig {
     this.format,
     required this.contents,
     this.codeSign,
+    this.window,
   });
 
   factory MakeDmgConfig.fromJson(Map<String, dynamic> json) {
@@ -158,6 +161,8 @@ class MakeDmgConfig extends MakeConfig {
       codeSign: json['code-sign'] != null
           ? DmgCodeSign.fromJson(json['code-sign'])
           : null,
+      window:
+          json['window'] != null ? DmgWindow.fromJson(json['window']) : null,
     );
   }
   final String title;
@@ -168,6 +173,7 @@ class MakeDmgConfig extends MakeConfig {
   final String? format;
   final List<DmgContent> contents;
   final DmgCodeSign? codeSign;
+  final DmgWindow? window;
 
   @override
   Map<String, dynamic> toJson() {
@@ -180,6 +186,7 @@ class MakeDmgConfig extends MakeConfig {
       'format': format,
       'contents': contents.map((e) => e.toJson()).toList(),
       'code-sign': codeSign?.toJson(),
+      'window': window?.toJson(),
     }..removeWhere((key, value) => value == null);
   }
 }


### PR DESCRIPTION
when build `macos` dmg, `make_config.yaml`'s window size & position have no effect.
this PR fix this.
```yaml
title: some_app
# window have no effect
window:
  size:
    width: 600
    height: 128
contents:
  - x: 100
    y: 64
    type: link
    path: "/Applications"
  - x: 200
    y: 64
    type: file
    path: some_app.app
```