### PR TITLE
Fix: Windows build failing due to invalid path in Flutter v3.16.0 and v3.15.0-pre 

### DIFF
--- a/packages/flutter_app_builder/lib/src/builders/windows/build_windows_result.dart
+++ b/packages/flutter_app_builder/lib/src/builders/windows/build_windows_result.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_app_builder/src/build_config.dart';
@@ -14,10 +15,63 @@ class BuildWindowsResultResolver extends BuildResultResolver {
 class BuildWindowsResult extends BuildResult {
   BuildWindowsResult(BuildConfig config) : super(config);
 
+  String? _arch;
+
+  String get arch {
+    if (_arch == null) {
+      final winArch = Platform.environment['PROCESSOR_ARCHITECTURE'];
+      if (winArch == 'ARM64') {
+        _arch = 'arm64';
+      } else {
+        _arch = 'x64';
+      }
+    }
+    return _arch!;
+  }
+
+  set arch(String value) {
+    _arch = value;
+  }
+
+  bool isVersionGreaterOrEqual(String fromVersion, String toVersion) {
+    if (fromVersion == toVersion) {
+      return true;
+    }
+
+    final from = fromVersion.split('.').map(int.parse).toList();
+    final to = toVersion.split('.').map(int.parse).toList();
+
+    if (from[0] > to[0]) {
+      return true;
+    } else if (from[0] == to[0] && from[1] > to[1]) {
+      return true;
+    } else if (from[0] == to[0] && from[1] == to[1] && from[2] > to[2]) {
+      return true;
+    }
+    return false;
+  }
+
   @override
   Directory get outputDirectory {
     String buildMode = ReCase(config.mode.name).sentenceCase;
-    String path = 'build/windows/runner/$buildMode';
+    final versionInfo = jsonDecode(
+      Process.runSync('flutter', ['--version', '--machine'], runInShell: true)
+          .stdout
+          .toString(),
+    ) as Map<String, dynamic>;
+
+    final flutterVersion = versionInfo['frameworkVersion'] as String;
+    final flutterChannel = versionInfo['channel'] as String;
+
+    String path;
+    if ((flutterChannel == 'master' &&
+            isVersionGreaterOrEqual(flutterVersion, '3.15.0')) ||
+        (flutterChannel != 'master' &&
+            isVersionGreaterOrEqual(flutterVersion, '3.16.0'))) {
+      path = 'build/windows/$arch/runner/$buildMode';
+    } else {
+      path = 'build/windows/runner/$buildMode';
+    }
     return Directory(path);
   }
 }


### PR DESCRIPTION
Fixes #145 