### PR TITLE
Fix AppImage output path to use correct casing

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/appimage/app_package_maker_appimage.dart
+++ b/packages/flutter_app_packager/lib/src/makers/appimage/app_package_maker_appimage.dart
@@ -13,7 +13,7 @@ class AppPackageMakerAppImage extends AppPackageMaker {
   @override
   bool get isSupportedOnCurrentPlatform => Platform.isLinux;
   @override
-  String get packageFormat => 'appimage';
+  String get packageFormat => 'AppImage';
 
   @override
   MakeConfigLoader get configLoader {
@@ -234,7 +234,7 @@ class AppPackageMakerAppImage extends AppPackageMaker {
             makeConfig.packagingDirectory.path,
             '${makeConfig.appName}.AppDir',
           ),
-          makeConfig.outputFile.path.replaceAll('.appimage', '.AppImage'),
+          makeConfig.outputFile.path,
         ],
         environment: {
           'ARCH': 'x86_64',

--- a/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
@@ -118,7 +118,7 @@ class MakeAppImageConfigLoader extends DefaultMakeConfigLoader {
       buildOutputFiles: buildOutputFiles,
     );
     final map = loadMakeConfigYaml(
-      '$platform/packaging/$packageFormat/make_config.yaml',
+      '$platform/packaging/${packageFormat.toLowerCase()}/make_config.yaml',
     );
     return MakeAppImageConfig.fromJson(map).copyWith(baseMakeConfig);
   }


### PR DESCRIPTION
The app image builder is currently broken because the `appimagetool` is outputting with an extension of `.AppImage`, but the artifact extension is saved as `.appimage` (without capitalization). This pull request should fix the capitalization problems.