### PR TITLE
fix: Unhandled exception Null check operator used on a null value

### DIFF
--- a/packages/flutter_app_builder/lib/src/commands/flutter.dart
+++ b/packages/flutter_app_builder/lib/src/commands/flutter.dart
@@ -28,7 +28,7 @@ class FlutterVersion {
       engineRevision: json['engineRevision'] as String?,
       dartSdkVersion: json['dartSdkVersion'] as String?,
       devToolsVersion: json['devToolsVersion'] as String?,
-      flutterVersion: json['flutterVersion'] as String?,
+      flutterVersion: json['flutterVersion'] as String? ?? (json['frameworkVersion'] as String?),
     );
   }
 


### PR DESCRIPTION
fixed https://github.com/leanflutter/flutter_distributor/issues/151

flutter 3.7 没有 flutterVersion 输出

```
flutter --version --machine 
{
  "frameworkVersion": "3.7.12",
  "channel": "stable",
  "repositoryUrl": "https://github.com/flutter/flutter.git",
  "frameworkRevision": "4d9e56e694b656610ab87fcf2efbcd226e0ed8cf",
  "frameworkCommitDate": "2023-04-17 21:47:46 -0400",
  "engineRevision": "1a65d409c7a1438a34d21b60bf30a6fd5db59314",
  "dartSdkVersion": "2.19.6",
  "devToolsVersion": "2.20.1",
  "flutterRoot": "/Users/zacksleo/flutter"
}
```