### PR TITLE
[rpm] check if print-rpath outputs $ORIGIN and not if the output path has /home

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -106,7 +106,7 @@ class AppPackageMakerRPM extends AppPackageMaker {
           file.path,
         ],
       );
-      if (processResult.stdout.toString().contains('/home')) {
+      if (processResult.stdout.toString() != ('$ORIGIN')) {
         await $(
           'patchelf',
           [


### PR DESCRIPTION
This aims to check if the path equals to $ORIGIN, and not /home, as projects can be created outside of the /home folder

**NOTE: THIS PULL REQUEST WASN'T TESTED AS I WASN'T ABLE TO TEST ON MY SYSTEM**