### PR TITLE
Fixing spaces in paths

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/dmg/app_package_maker_dmg.dart
+++ b/packages/flutter_app_packager/lib/src/makers/dmg/app_package_maker_dmg.dart
@@ -37,10 +37,12 @@ class AppPackageMakerDmg extends AppPackageMaker {
         .first;
 
     try {
-      await $('cp', ['-RH', '"${appFile.path}"', '"${packagingDirectory.path}"']);
-      
-      await $('cp', ['-RH', 'macos/packaging/dmg/.', '"${packagingDirectory.path}"']);
-      
+      await $(
+          'cp', ['-RH', '"${appFile.path}"', '"${packagingDirectory.path}"']);
+
+      await $('cp',
+          ['-RH', 'macos/packaging/dmg/.', '"${packagingDirectory.path}"']);
+
       File makeDmgConfigJsonFile = File(
         '${packagingDirectory.path}/make_config.json',
       );

--- a/packages/flutter_app_packager/lib/src/makers/dmg/app_package_maker_dmg.dart
+++ b/packages/flutter_app_packager/lib/src/makers/dmg/app_package_maker_dmg.dart
@@ -37,10 +37,10 @@ class AppPackageMakerDmg extends AppPackageMaker {
         .first;
 
     try {
-      await $('cp', ['-RH', appFile.path, packagingDirectory.path]);
-
-      await $('cp', ['-RH', 'macos/packaging/dmg/.', packagingDirectory.path]);
-
+      await $('cp', ['-RH', '"${appFile.path}"', '"${packagingDirectory.path}"']);
+      
+      await $('cp', ['-RH', 'macos/packaging/dmg/.', '"${packagingDirectory.path}"']);
+      
       File makeDmgConfigJsonFile = File(
         '${packagingDirectory.path}/make_config.json',
       );


### PR DESCRIPTION
in macos if path has spaces in it the files doesnt get copied 
<img width="939" alt="image" src="https://github.com/leanflutter/flutter_distributor/assets/25157308/fe097b13-8403-4300-ba11-dcec35f9c21b">

so this adds qoutes to command to fix the path space getting escaped 