### PR TITLE
Let users know that a version check is in progress

### DIFF
--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -40,8 +40,11 @@ Future<void> main(List<String> args) async {
   }
 
   if (argResults['version-check']) {
+    logger.info('Checking version');
     // Check version of flutter_distributor on every run
-    await distributor.checkVersion();
+    if (!await distributor.checkVersion()) {
+      logger.info('Up to date');
+    }
   }
 
   return runner.runCommand(argResults);

--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -96,7 +96,7 @@ class FlutterDistributor {
     return null;
   }
 
-  Future<void> checkVersion() async {
+  Future<bool> checkVersion() async {
     String? currentVersion = await _getCurrentVersion();
     String? latestVersion =
         await PubDevApi.getLatestVersionFromPackage('flutter_distributor');
@@ -113,8 +113,9 @@ class FlutterDistributor {
         '',
       ].join('\n');
       print(msg);
+      return Future.value(true);
     }
-    return Future.value();
+    return Future.value(false);
   }
 
   Future<String?> getCurrentVersion() async {


### PR DESCRIPTION
There is a pause (least for me) as flutter_distributor checks to see if the user is using the most recent. We should tell people what is going on.