### PR TITLE
Errors aren't rethrown so they don't get passed to CI, this is inconsistent with other commands.

### DIFF
--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -270,6 +270,7 @@ class FlutterDistributor {
     } on Error catch (error) {
       logger.severe(error.toString().brightRed());
       logger.severe(error.stackTrace.toString().brightRed());
+      rethrow;
     }
     return publishResultList;
   }
@@ -367,6 +368,7 @@ class FlutterDistributor {
           stacktrace,
         ].join('\n'),
       );
+      rethrow;
     }
     return Future.value();
   }


### PR DESCRIPTION
CI wasn't failing when I was running `release`:

![image](https://github.com/user-attachments/assets/09c27862-b306-4569-a65b-3836192de432)

This seems to be because `release` isn't rethrowing as per the other commands. Adding resolves the issue:

Before: 

![Screenshot_20240824_143534](https://github.com/user-attachments/assets/8ee4a6b0-1c4e-4aaf-883d-949f84896dcf)

After:

![Screenshot_20240824_143610](https://github.com/user-attachments/assets/e7a89400-0ce4-463c-889d-8ae96c274526)

It does make it more verbose (redundantly) and the new stack trace doesn't have formatting.
