### PR TITLE
Pacman was missing from readme + alphabetical order

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -25,14 +25,15 @@
 
 ### 制作器
 
-- [apk](./packages/flutter_app_packager/lib/src/makers/apk/) - 为你的应用创建一个 `apk` 包。
 - [aab](./packages/flutter_app_packager/lib/src/makers/aab/) - 为你的应用创建一个 `aab` 包。
+- [apk](./packages/flutter_app_packager/lib/src/makers/apk/) - 为你的应用创建一个 `apk` 包。
 - [appimage](./packages/flutter_app_packager/lib/src/makers/appimage/) - 为你的应用创建一个 `AppImage` 包。
 - [deb](./packages/flutter_app_packager/lib/src/makers/deb/) - 为你的应用创建一个 `deb` 包。
 - [dmg](./packages/flutter_app_packager/lib/src/makers/dmg/) - 为你的应用创建一个 `dmg` 包。
 - [exe](./packages/flutter_app_packager/lib/src/makers/exe/) - 为你的应用创建一个 `exe` 包。
 - [ipa](./packages/flutter_app_packager/lib/src/makers/ipa/) - 为你的应用创建一个 `ipa` 包。
 - [msix](./packages/flutter_app_packager/lib/src/makers/msix/) - 为你的应用创建一个 `msix` 包。
+- [pacman](./packages/flutter_app_packager/lib/src/makers/pacman/) - 为你的应用创建一个 `pacman` 包。
 - [pkg](./packages/flutter_app_packager/lib/src/makers/pkg/) - 为你的应用创建一个 `pkg` 包。
 - [rpm](./packages/flutter_app_packager/lib/src/makers/rpm/) - 为你的应用创建一个 `rpm` 包。
 - [zip](./packages/flutter_app_packager/lib/src/makers/zip/) - 为你的应用创建一个 `zip` 包。

--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ The full documentation can be found on [distributor.leanflutter.dev](https://dis
 
 ### Makers
 
-- [apk](./packages/flutter_app_packager/lib/src/makers/apk/) - Create a `apk` package for your app.
 - [aab](./packages/flutter_app_packager/lib/src/makers/aab/) - Create a `aab` package for your app.
+- [apk](./packages/flutter_app_packager/lib/src/makers/apk/) - Create a `apk` package for your app.
 - [appimage](./packages/flutter_app_packager/lib/src/makers/appimage/) - Create a `AppImage` package for your app.
 - [deb](./packages/flutter_app_packager/lib/src/makers/deb/) - Create a `deb` package for your app.
 - [dmg](./packages/flutter_app_packager/lib/src/makers/dmg/) - Create a `dmg` package for your app.
 - [exe](./packages/flutter_app_packager/lib/src/makers/exe/) - Create a `exe` package for your app.
 - [ipa](./packages/flutter_app_packager/lib/src/makers/ipa/) - Create a `ipa` package for your app.
 - [msix](./packages/flutter_app_packager/lib/src/makers/msix/) - Create a `msix` package for your app.
+- [pacman](./packages/flutter_app_packager/lib/src/makers/pacman/) - Create a `pacman` package for your app.
 - [pkg](./packages/flutter_app_packager/lib/src/makers/pkg/) - Create a `pkg` package for your app.
 - [rpm](./packages/flutter_app_packager/lib/src/makers/rpm/) - Create a `rpm` package for your app.
 - [zip](./packages/flutter_app_packager/lib/src/makers/zip/) - Create a `zip` package for your app.


### PR DESCRIPTION
There is also `direct` but I'm not sure if that's supposed to be there or not.