### PR TITLE
This adds some tolerance for commented out distribute_options.yaml sections

### DIFF
--- a/packages/flutter_distributor/lib/src/release.dart
+++ b/packages/flutter_distributor/lib/src/release.dart
@@ -12,7 +12,7 @@ class Release {
     if (json.containsKey('variables') && json['variables'] != null) {
       variables = Map<String, String>.from(json['variables']);
     }
-    List<ReleaseJob> jobs = (json['jobs'] as List)
+    List<ReleaseJob> jobs = (json['jobs'] as List? ?? [])
         .map((item) => ReleaseJob.fromJson(item))
         .toList();
     return Release(


### PR DESCRIPTION
I am using the same `distribute_options.yaml` in multiple locations. I comment out the sections of deploy for what is and isn't relevant. I would like to keep on doing this as it means updating all the repositories is easier. So I instead made the jobs listing null safe so that it would work with "null" / empty yaml lists:

![Screenshot_20240824_165339](https://github.com/user-attachments/assets/34b4b77f-6530-435f-b56e-4535a4868fa9)

Before:

![Screenshot_20240824_165314](https://github.com/user-attachments/assets/d856174e-6adb-4a5a-9015-30ca84bc8e68)

After:

![Screenshot_20240824_165322](https://github.com/user-attachments/assets/27a7e4ff-23db-413a-b251-4c64ca598f97)
