### PR TITLE
fix:can not set icon file when packaging windows exe

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
@@ -24,6 +24,13 @@ class MakeExeConfig extends MakeConfig {
         json['locales'] != null ? List<String>.from(json['locales']) : null;
     if (locales == null || locales.isEmpty) locales = ['en'];
 
+    // use absolute path
+    String iconfile = '';
+    if (json['setup_icon_file'] != null) {
+      String currentDirectory = Directory.current.path;
+      iconfile = p.join(currentDirectory, json['setup_icon_file']);
+    }
+
     MakeExeConfig makeExeConfig = MakeExeConfig(
       scriptTemplate: json['script_template'],
       appId: json['app_id'] ?? json['appId'],
@@ -34,7 +41,7 @@ class MakeExeConfig extends MakeConfig {
       createDesktopIcon: json['create_desktop_icon'],
       launchAtStartup: json['launch_at_startup'],
       installDirName: json['install_dir_name'],
-      setupIconFile: json['setup_icon_file'],
+      setupIconFile: iconfile,
       privilegesRequired: json['privileges_required'],
       locales: locales,
     );

--- a/website/src/content/docs/makers/exe.md
+++ b/website/src/content/docs/makers/exe.md
@@ -20,6 +20,8 @@ display_name: Hello 世界
 create_desktop_icon: true
 # See: https://jrsoftware.org/ishelp/index.php?topic=setup_defaultdirname
 # install_dir_name: "D:\\HELLO-WORLD"
+# This path is relative to the root directory of your project; The format of icon file must be ico, can not be png or others
+# setup_icon_file: windows\runner\resources\app_icon.ico
 locales:
   - en
   - zh

--- a/website/src/content/docs/zh-hans/makers/exe.md
+++ b/website/src/content/docs/zh-hans/makers/exe.md
@@ -20,6 +20,8 @@ display_name: Hello 世界
 create_desktop_icon: true
 # See: https://jrsoftware.org/ishelp/index.php?topic=setup_defaultdirname
 # install_dir_name: "D:\\HELLO-WORLD"
+# 这里的路径是相对于项目根目录的路径； 图标格式必须是ico格式，不能是png或其它
+# setup_icon_file: windows\runner\resources\app_icon.ico
 locales:
   - en
   - zh


### PR DESCRIPTION
修复issues [打包windows平台exe格式时，make_config.yaml里面的设置项setup_icon_file如果有值，会报错 #245 ](https://github.com/leanflutter/flutter_distributor/issues/245)