### PR TITLE
Propagate build errors to return cmd status correctly

### DIFF
--- a/packages/flutter_distributor/bin/command_package.dart
+++ b/packages/flutter_distributor/bin/command_package.dart
@@ -129,7 +129,7 @@ class CommandPackage extends Command {
       exit(1);
     }
 
-    return distributor.package(
+    distributor.package(
       platform,
       targets,
       channel: channel,
@@ -137,6 +137,8 @@ class CommandPackage extends Command {
       cleanBeforeBuild: !isSkipClean,
       buildArguments: buildArguments,
     );
+
+    return null;
   }
 
   Map<String, dynamic> _generateBuildArgs(String? flutterBuildArgs) {

--- a/packages/flutter_distributor/bin/command_publish.dart
+++ b/packages/flutter_distributor/bin/command_publish.dart
@@ -221,10 +221,12 @@ class CommandPublish extends Command {
             ? Directory(path)
             : File(path);
 
-    return distributor.publish(
+    distributor.publish(
       fileSystemEntity,
       targets,
       publishArguments: publishArguments,
     );
+
+    return null;
   }
 }

--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:flutter_distributor/flutter_distributor.dart';
@@ -44,5 +46,9 @@ Future<void> main(List<String> args) async {
     await distributor.checkVersion();
   }
 
-  return runner.runCommand(argResults);
+  dynamic result = await runner.runCommand(argResults);
+  if (result != null) {
+    exit(-1);
+  }
+  return result;
 }

--- a/packages/flutter_distributor/lib/src/flutter_distributor.dart
+++ b/packages/flutter_distributor/lib/src/flutter_distributor.dart
@@ -274,7 +274,7 @@ class FlutterDistributor {
     return publishResultList;
   }
 
-  Future<void> release(
+  Future<dynamic> release(
     String name, {
     required List<String> jobNameList,
     required List<String> skipJobNameList,
@@ -367,15 +367,16 @@ class FlutterDistributor {
           stacktrace,
         ].join('\n'),
       );
+      return error;
     }
-    return Future.value();
+    return null;
   }
 
-  Future<void> upgrade() async {
+  Future<dynamic> upgrade() async {
     await $(
       'dart',
       ['pub', 'global', 'activate', 'flutter_distributor'],
     );
-    return Future.value();
+    return null;
   }
 }


### PR DESCRIPTION
# Now:
```
RELEASE FAILED in 23s
MakeError
#0      AppPackageMakerDeb._make (package:flutter_app_packager/src/makers/deb/app_package_maker_deb.dart:143:7)
<asynchronous suspension>
#1      FlutterDistributor.package (package:flutter_distributor/src/flutter_distributor.dart:183:35)
<asynchronous suspension>
#2      FlutterDistributor.release (package:flutter_distributor/src/flutter_distributor.dart:331:45)
<asynchronous suspension>
#3      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#4      main (file:///home/arran/Documents/Projects/flutter_distributor/packages/flutter_distributor/bin/main.dart:52:20)
<asynchronous suspension>

arran@arran-desktop:/home/arran/Documents/Projects/which_browser 35706 
% echo $?                                                                                                                      
255
```

# Was:

```

RELEASE FAILED in 23s
MakeError
#0      AppPackageMakerDeb._make (package:flutter_app_packager/src/makers/deb/app_package_maker_deb.dart:143:7)
<asynchronous suspension>
#1      FlutterDistributor.package (package:flutter_distributor/src/flutter_distributor.dart:183:35)
<asynchronous suspension>
#2      FlutterDistributor.release (package:flutter_distributor/src/flutter_distributor.dart:331:45)
<asynchronous suspension>
#3      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>

arran@arran-desktop:/home/arran/Documents/Projects/which_browser 35703 
% echo $?                                                                                                                      
0

```

# Consequence: 

![image](https://github.com/user-attachments/assets/1c00317c-9438-47c6-a854-b6e788c57a02)

# Discussion

I would have preferred to use a throw catch, however I was unsure if that was a great idea. I did something similar to this in https://github.com/leanflutter/flutter_distributor/pull/219 however it didn't work in the case the errors were not rethrown.

# Note

Release was tested, others not so much.