### PR TITLE
Better error if entity is not a file

### DIFF
--- a/packages/flutter_app_publisher/lib/src/publishers/github/app_package_publisher_github.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/github/app_package_publisher_github.dart
@@ -28,7 +28,9 @@ class AppPackagePublisherGithub extends AppPackagePublisher {
     Map<String, dynamic>? publishArguments,
     PublishProgressCallback? onPublishProgress,
   }) async {
-    File file = fileSystemEntity as File;
+    if (fileSystemEntity is! File) {
+      throw PublishError('FileSystemEntity:${fileSystemEntity.path} is not a file');
+    }
     PublishGithubConfig publishConfig = PublishGithubConfig.parse(
       environment,
       publishArguments,
@@ -55,7 +57,7 @@ class AppPackagePublisherGithub extends AppPackagePublisher {
     }
     // Upload file
     String browserDownloadUrl =
-        await _uploadReleaseAsset(file, uploadUrl!, onPublishProgress);
+        await _uploadReleaseAsset(fileSystemEntity, uploadUrl!, onPublishProgress);
     return PublishResult(
       url: browserDownloadUrl,
     );


### PR DESCRIPTION
Minor fix. Provides a better error for:

```
Unhandled exception:
PublishError: DioException [bad response]: This exception was thrown because the response has a status code of 422 and RequestOptions.validateStatus was configured to throw for this status code. The status code of 422 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled" Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.

#0      AppPackagePublisherGithub._uploadReleaseAsset (package:flutter_app_publisher/src/publishers/github/app_package_publisher_github.dart:130:7)
<asynchronous suspension>
#1      AppPackagePublisherGithub.publish (package:flutter_app_publisher/src/publishers/github/app_package_publisher_github.dart:58:9)
<asynchronous suspension>
#2      FlutterAppPublisher.publish (package:flutter_app_publisher/src/flutter_app_publisher.dart:30:12)
<asynchronous suspension>
#3      UnifiedDistributor.publish (package:unified_distributor/src/unified_distributor.dart:269:39)
<asynchronous suspension>
#4      UnifiedDistributor.release (package:unified_distributor/src/unified_distributor.dart:372:13)
<asynchronous suspension>
#5      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#6      main (file:///C:/Users/runneradmin/.pub-cache/hosted/pub.dev/fastforge-0.5.1/bin/main.dart:10:10)
<asynchronous suspension>
RELEASE FAILED in 59s
PublishError: DioException [bad response]: This exception was thrown because the response has a status code of 422 and RequestOptions.validateStatus was configured to throw for this status code.
The status code of 422 has the following meaning: "Client error - the request contains bad syntax or cannot be fulfilled"
Read more about status codes at https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
In order to resolve this exception you typically have either to verify and fix your request code or you have to fix the server code.

#0      AppPackagePublisherGithub._uploadReleaseAsset (package:flutter_app_publisher/src/publishers/github/app_package_publisher_github.dart:130:7)
<asynchronous suspension>
#1      AppPackagePublisherGithub.publish (package:flutter_app_publisher/src/publishers/github/app_package_publisher_github.dart:58:9)
<asynchronous suspension>
#2      FlutterAppPublisher.publish (package:flutter_app_publisher/src/flutter_app_publisher.dart:30:12)
<asynchronous suspension>
#3      UnifiedDistributor.publish (package:unified_distributor/src/unified_distributor.dart:269:39)
<asynchronous suspension>
#4      UnifiedDistributor.release (package:unified_distributor/src/unified_distributor.dart:372:13)
<asynchronous suspension>
#5      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#6      main (file:///C:/Users/runneradmin/.pub-cache/hosted/pub.dev/fastforge-0.5.1/bin/main.dart:10:10)
<asynchronous suspension>
```