### PR TITLE
Fix: Show correct app icon on Wayland

### DIFF
--- a/packages/flutter_app_packager/lib/src/api/make_config.dart
+++ b/packages/flutter_app_packager/lib/src/api/make_config.dart
@@ -182,7 +182,7 @@ class MakeLinuxPackageConfig extends MakeConfig {
   String get appBinaryName {
     if (_appBinaryName == null) {
       final cMakeListsFile = File('linux/CMakeLists.txt');
-      final RegExp regex = RegExp(r'(?<=set\(BINARY_NAME\s")[^"]+(?="\))');
+      final RegExp regex = RegExp(r'(?<=set\(APPLICATION_ID\s")[^"]+(?="\))');
       final Match? match = regex.firstMatch(cMakeListsFile.readAsStringSync());
 
       if (match != null) {


### PR DESCRIPTION
This updates the `appBinaryName` getter to extract `APPLICATION_ID` from the `linux/CMakeLists.txt` file instead of `BINARY_NAME`. This change ensures the app window is correctly associated with the .desktop file.

Reference: [link](https://github.com/flutter/flutter/issues/53229#issuecomment-2347348554)