### PR TITLE
Refactor: Modify detection process for Inno Setup 6

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_compiler.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_compiler.dart
@@ -26,7 +26,7 @@ class InnoSetupCompiler {
         processResult = await $('ISCC', [file.path]);
       } on ProcessException {
         throw Exception(
-            '`Inno Setup 6` was not installed or ISCC is not in PATH.');
+            '\'Inno Setup 6\' was not installed or ISCC is not in PATH.');
       }
     }
 

--- a/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_compiler.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_compiler.dart
@@ -6,19 +6,29 @@ import 'package:shell_executor/shell_executor.dart';
 
 class InnoSetupCompiler {
   Future<bool> compile(InnoSetupScript script) async {
+    File file = await script.createFile();
+
+    ProcessResult processResult;
+
+    // First, try the default installation path
     Directory innoSetupDirectory =
         Directory('C:\\Program Files (x86)\\Inno Setup 6');
 
-    if (!innoSetupDirectory.existsSync()) {
-      throw Exception('`Inno Setup 6` was not installed.');
+    if (innoSetupDirectory.existsSync()) {
+      // Use ISCC from the default installation directory
+      processResult = await $(
+        p.join(innoSetupDirectory.path, 'ISCC.exe'),
+        [file.path],
+      );
+    } else {
+      // Fall back to PATH
+      try {
+        processResult = await $('ISCC', [file.path]);
+      } on ProcessException {
+        throw Exception(
+            '`Inno Setup 6` was not installed or ISCC is not in PATH.');
+      }
     }
-
-    File file = await script.createFile();
-
-    ProcessResult processResult = await $(
-      p.join(innoSetupDirectory.path, 'ISCC.exe'),
-      [file.path],
-    );
 
     if (processResult.exitCode != 0) {
       return false;


### PR DESCRIPTION
This pull request improves the robustness of the `InnoSetupCompiler` by adding a fallback mechanism for locating the Inno Setup compiler executable. Instead of failing if the default installation directory is not found, the code now attempts to use `ISCC` from the system `PATH` before throwing an error.

**Improvements to Inno Setup compiler execution:**

* Updated the `compile` method in `inno_setup_compiler.dart` to first try running `ISCC.exe` from the default installation directory, and if not found, fall back to invoking `ISCC` from the system `PATH`. Throws a clear exception if neither is available.