### PR TITLE
fix(rpm): enable post-install scripts and fix post-uninstall logic

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -30,6 +30,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
     this.prep,
     this.build,
     this.install,
+    this.postun,
     List<String>? postinstallScripts,
     List<String>? postuninstallScripts,
     this.files,
@@ -71,7 +72,8 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
           : null,
       postuninstallScripts: json['postuninstall_scripts'] != null
           ? List.castFrom<dynamic, String>(json['postuninstall_scripts'])
-          : (json['postun'] != null ? [json['postun'] as String] : null),
+          : null,
+      postun: json['postun'] as String?,
       files: json['files'] as String?,
       defattr: json['defattr'] as String?,
       attr: json['attr'] as String?,
@@ -108,6 +110,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
   String? prep;
   String? build;
   String? install;
+  String? postun;
   String? files;
   String? defattr;
   String? attr;
@@ -121,6 +124,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
 
   List<String> get postunScripts => [
     'update-mime-database %{_datadir}/mime &> /dev/null || :',
+    if (postun != null) postun!,
     ..._postuninstallScripts,
   ];
 

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -30,13 +30,15 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
     this.prep,
     this.build,
     this.install,
-    this.postun,
+    List<String>? postinstallScripts,
+    List<String>? postuninstallScripts,
     this.files,
     this.defattr,
     this.attr,
     this.changelog,
     this.specMacros,
-  });
+  })  : _postinstallScripts = postinstallScripts ?? [],
+        _postuninstallScripts = postuninstallScripts ?? [];
 
   factory MakeRPMConfig.fromJson(Map<String, dynamic> json) {
     return MakeRPMConfig(
@@ -64,7 +66,12 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
       prep: json['prep'] as String?,
       build: json['build'] as String?,
       install: json['install'] as String?,
-      postun: json['postun'] as String?,
+      postinstallScripts: json['postinstall_scripts'] != null
+          ? List.castFrom<dynamic, String>(json['postinstall_scripts'])
+          : null,
+      postuninstallScripts: json['postuninstall_scripts'] != null
+          ? List.castFrom<dynamic, String>(json['postuninstall_scripts'])
+          : (json['postun'] != null ? [json['postun'] as String] : null),
       files: json['files'] as String?,
       defattr: json['defattr'] as String?,
       attr: json['attr'] as String?,
@@ -82,6 +89,8 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
   List<String>? supportedMimeType;
   List<String>? actions;
   List<String>? categories;
+  List<String> _postinstallScripts;
+  List<String> _postuninstallScripts;
 
   //RPM preamble Spec file fields
   String? summary;
@@ -99,12 +108,21 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
   String? prep;
   String? build;
   String? install;
-  String? postun;
   String? files;
   String? defattr;
   String? attr;
   String? changelog;
   List<String>? specMacros;
+
+  List<String> get postScripts => [
+    'update-mime-database %{_datadir}/mime &> /dev/null || :',
+    ..._postinstallScripts,
+  ];
+
+  List<String> get postunScripts => [
+    'update-mime-database %{_datadir}/mime &> /dev/null || :',
+    ..._postuninstallScripts,
+  ];
 
   @override
   Map<String, dynamic> toJson() {
@@ -140,8 +158,8 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
             'cp -r $appBinaryName.png %{buildroot}%{_datadir}/pixmaps/%{name}.png',
             'cp -r $appBinaryName*.xml %{buildroot}%{_datadir}/metainfo/%{name}.appdata.xml || :',
           ].join('\n'),
-          '%postun': ['update-mime-database %{_datadir}/mime &> /dev/null || :']
-              .join('\n'),
+          '%post': postScripts.join('\n'),
+          '%postun': postunScripts.join('\n'),
           '%files': [
             '%{_bindir}/%{name}',
             '%{_datadir}/%{name}',

--- a/packages/flutter_app_packager/pubspec.yaml
+++ b/packages/flutter_app_packager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_app_packager
 description: Package your Flutter app into OS-specific bundles (.dmg, .exe, etc.) via Dart or the command line.
-version: 0.6.10
+version: 0.6.11
 homepage: https://github.com/fastforgedev/fastforge
 
 environment:

--- a/packages/flutter_app_packager/pubspec.yaml
+++ b/packages/flutter_app_packager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_app_packager
 description: Package your Flutter app into OS-specific bundles (.dmg, .exe, etc.) via Dart or the command line.
-version: 0.6.11
+version: 0.6.10
 homepage: https://github.com/fastforgedev/fastforge
 
 environment:

--- a/packages/flutter_app_packager/test/src/makers/linux_desktop_entry_test.dart
+++ b/packages/flutter_app_packager/test/src/makers/linux_desktop_entry_test.dart
@@ -51,6 +51,50 @@ void main() {
       expect(files['DESKTOP'], isNot(contains('\nVersion=')));
     });
 
+    test('rpm places lifecycle scripts outside the install section', () {
+      final config = MakeRPMConfig.fromJson({
+        'display_name': 'Test App',
+        'postinstall_scripts': ['echo postinstall'],
+        'postuninstall_scripts': ['echo postuninstall'],
+      })..pubspec = _pubspec();
+
+      final spec = config.toFilesString()['SPEC']!;
+      final installSection = spec.substring(
+        spec.indexOf('%install'),
+        spec.indexOf('\n%post\n'),
+      );
+
+      expect(installSection, isNot(contains('update-mime-database')));
+      expect(
+        spec,
+        contains(
+          '%post\n'
+          'update-mime-database %{_datadir}/mime &> /dev/null || :\n'
+          'echo postinstall',
+        ),
+      );
+      expect(
+        spec,
+        contains(
+          '%postun\n'
+          'update-mime-database %{_datadir}/mime &> /dev/null || :\n'
+          'echo postuninstall',
+        ),
+      );
+    });
+
+    test('rpm retains the legacy postun constructor parameter', () {
+      final config = MakeRPMConfig(
+        displayName: 'Test App',
+        postun: 'echo legacy-postun',
+      )..pubspec = _pubspec();
+
+      expect(
+        config.toFilesString()['SPEC'],
+        contains('echo legacy-postun'),
+      );
+    });
+
     test('pacman keeps package version out of the desktop entry', () {
       final config = MakePacmanConfig(
         displayName: 'Test App',


### PR DESCRIPTION
Fixes https://github.com/fastforgedev/fastforge/issues/306

- Added support for `%post` scripts in RPM spec generation (previously missing).
- Fixed `%postun` implementation which was ignoring configuration fields due to hardcoded values.
- Aligned configuration API with Debian packager by supporting `postinstall_scripts` and `postuninstall_scripts` lists.
- Added backward compatibility for legacy string key (`postun`).