### PR TITLE
fix(rpm): generalize RPATH sanitization to support non-home build directories

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -106,7 +106,9 @@ class AppPackageMakerRPM extends AppPackageMaker {
           file.path,
         ],
       );
-      if (processResult.stdout.toString().contains('/home')) {
+      final rpath = processResult.stdout.toString().trim();
+      // Fix RPATH if it is an absolute path (starts with /) and not yet fixed ($ORIGIN)
+      if (rpath.startsWith('/') && !rpath.contains('\$ORIGIN')) {
         await $(
           'patchelf',
           [

--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -6,6 +6,17 @@ import 'package:flutter_app_packager/src/makers/rpm/rpmbuild.dart';
 import 'package:path/path.dart' as path;
 import 'package:shell_executor/shell_executor.dart';
 
+String sanitizeRpmRpath(String rpath) {
+  final sanitizedEntries = <String>[];
+  for (final entry in rpath.split(':')) {
+    final sanitizedEntry = path.posix.isAbsolute(entry) ? r'$ORIGIN' : entry;
+    if (!sanitizedEntries.contains(sanitizedEntry)) {
+      sanitizedEntries.add(sanitizedEntry);
+    }
+  }
+  return sanitizedEntries.join(':');
+}
+
 class AppPackageMakerRPM extends AppPackageMaker {
   @override
   List<Command> get requirements => [rpmbuild];
@@ -107,13 +118,13 @@ class AppPackageMakerRPM extends AppPackageMaker {
         ],
       );
       final rpath = processResult.stdout.toString().trim();
-      // Fix RPATH if it is an absolute path (starts with /) and not yet fixed ($ORIGIN)
-      if (rpath.startsWith('/') && !rpath.contains('\$ORIGIN')) {
+      final sanitizedRpath = sanitizeRpmRpath(rpath);
+      if (sanitizedRpath != rpath) {
         await $(
           'patchelf',
           [
             '--set-rpath',
-            '\$ORIGIN',
+            sanitizedRpath,
             file.path,
           ],
         );

--- a/packages/flutter_app_packager/test/src/makers/rpm_rpath_test.dart
+++ b/packages/flutter_app_packager/test/src/makers/rpm_rpath_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_app_packager/src/makers/rpm/app_package_maker_rpm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('sanitizeRpmRpath', () {
+    test('replaces a single absolute build path', () {
+      expect(sanitizeRpmRpath('/mnt/project/lib'), r'$ORIGIN');
+    });
+
+    test('removes absolute paths from mixed RPATH values', () {
+      expect(
+        sanitizeRpmRpath(r'$ORIGIN:/mnt/project/lib'),
+        r'$ORIGIN',
+      );
+      expect(
+        sanitizeRpmRpath(r'/mnt/project/lib:$ORIGIN'),
+        r'$ORIGIN',
+      );
+    });
+
+    test('preserves relative and origin-based entries', () {
+      expect(
+        sanitizeRpmRpath(r'$ORIGIN:$ORIGIN/../lib:plugins'),
+        r'$ORIGIN:$ORIGIN/../lib:plugins',
+      );
+    });
+
+    test('preserves an empty RPATH', () {
+      expect(sanitizeRpmRpath(''), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/fastforgedev/fastforge/issues/309

The previous logic for fixing RPATHs in shared libraries (`lib*_plugin.so`) only triggered if the path contained `/home`. This caused build paths to leak into the final package when building in other environments (e.g., `/mnt/...` in WSL, `/root` in Docker, or `/opt` in CI runners).

This commit changes the condition to check for any absolute path (starting with `/`) that isn't already set to `$ORIGIN`.