### PR TITLE
fix(rpm): remove system modification command from %install section

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -139,7 +139,6 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
             'cp -r $appBinaryName.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop',
             'cp -r $appBinaryName.png %{buildroot}%{_datadir}/pixmaps/%{name}.png',
             'cp -r $appBinaryName*.xml %{buildroot}%{_datadir}/metainfo/%{name}.appdata.xml || :',
-            'update-mime-database %{_datadir}/mime &> /dev/null || :',
           ].join('\n'),
           '%postun': ['update-mime-database %{_datadir}/mime &> /dev/null || :']
               .join('\n'),


### PR DESCRIPTION
Fixes https://github.com/fastforgedev/fastforge/issues/308

The `update-mime-database` command was being executed in the `%install` section. This caused "Permission denied" errors during the build process because it attempted to modify the host system's `/usr/share/mime` directory instead of the buildroot.

This command belongs in `%post` and `%postun` (which are already handled in https://github.com/fastforgedev/fastforge/pull/307), not in `%install`.