### PR TITLE
fix(rpm): enforce usage of appBinaryName for assets and fix symlink logic

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/app_package_maker_rpm.dart
@@ -125,7 +125,7 @@ class AppPackageMakerRPM extends AppPackageMaker {
     iconFile?.copy(
       path.join(
         buildPath,
-        makeConfig.appName + path.extension(iconFile.path),
+        makeConfig.appBinaryName + path.extension(iconFile.path),
       ),
     );
 
@@ -153,9 +153,9 @@ class AppPackageMakerRPM extends AppPackageMaker {
     }
 
     // create & write the files got from makeConfig
-    final specFile = File(path.join(specsPath, '${makeConfig.appName}.spec'));
+    final specFile = File(path.join(specsPath, '${makeConfig.appBinaryName}.spec'));
     final desktopEntryFile =
-        File(path.join(buildPath, '${makeConfig.appName}.desktop'));
+        File(path.join(buildPath, '${makeConfig.appBinaryName}.desktop'));
 
     if (!specFile.existsSync()) specFile.createSync();
     if (!desktopEntryFile.existsSync()) desktopEntryFile.createSync();

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_app_packager/src/api/app_package_maker.dart';
 
-class MakeRPMConfig extends MakeConfig {
+class MakeRPMConfig extends MakeLinuxPackageConfig {
   MakeRPMConfig({
     // Desktop file
     required this.displayName,
@@ -132,10 +132,10 @@ class MakeRPMConfig extends MakeConfig {
             'mkdir -p %{buildroot}%{_datadir}/metainfo',
             'mkdir -p %{buildroot}%{_datadir}/pixmaps',
             'cp -r %{name}/* %{buildroot}%{_datadir}/%{name}',
-            'ln -s %{_datadir}/%{name}/%{name} %{buildroot}%{_bindir}/%{name}',
-            'cp -r %{name}.desktop %{buildroot}%{_datadir}/applications',
-            'cp -r %{name}.png %{buildroot}%{_datadir}/pixmaps',
-            'cp -r %{name}*.xml %{buildroot}%{_datadir}/metainfo || :',
+            'ln -s %{_datadir}/%{name}/$appBinaryName %{buildroot}%{_bindir}/%{name}',
+            'cp -r $appBinaryName.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop',
+            'cp -r $appBinaryName.png %{buildroot}%{_datadir}/pixmaps/%{name}.png',
+            'cp -r $appBinaryName*.xml %{buildroot}%{_datadir}/metainfo/%{name}.appdata.xml || :',
             'update-mime-database %{_datadir}/mime &> /dev/null || :',
           ].join('\n'),
           '%postun': ['update-mime-database %{_datadir}/mime &> /dev/null || :']


### PR DESCRIPTION
Fixes https://github.com/fastforgedev/fastforge/issues/312

- Refactored `AppPackageMakerRPM` to use `appBinaryName` (from CMake) instead of `appName` (from pubspec) when generating the `.spec` file, `.desktop` file, and copying icons. This ensures consistency with the `metainfo` file logic and prevents "File not found" errors when the binary name differs from the project name.
- Updated `MakeRPMConfig` to extend `MakeLinuxPackageConfig` to correctly detect the `BINARY_NAME`.
- Updated the `%install` section in the spec file to source all assets (`.desktop`, `.png`, `.xml`) using `$appBinaryName` and symlink the correct binary `$appBinaryName` to `%{name}` in `/usr/bin`.