### PR TITLE
Use /opt for Debian package app files (also RPM and Pacman)

### DIFF
--- a/crates/app_packager/src/linux/deb.rs
+++ b/crates/app_packager/src/linux/deb.rs
@@ -55,13 +55,13 @@ impl AppPackager for LinuxDebPackager {
 
         // Create the required directory tree
         let debian_dir = pkg_dir.join("DEBIAN");
-        let share_app_dir = pkg_dir.join("usr/share").join(binary_name);
+        let share_app_dir = pkg_dir.join("opt").join(binary_name);
         let applications_dir = pkg_dir.join("usr/share/applications");
         std::fs::create_dir_all(&debian_dir)?;
         std::fs::create_dir_all(&share_app_dir)?;
         std::fs::create_dir_all(&applications_dir)?;
 
-        // Copy the flutter build output into /usr/share/{binary_name}/
+        // Copy the flutter build output into /opt/{binary_name}/
         copy_dir_contents(&config.build_output_dir, &share_app_dir)?;
 
         // Write DEBIAN/control (minimal placeholder; real deployments supply a
@@ -74,7 +74,7 @@ impl AppPackager for LinuxDebPackager {
 
         // Write DEBIAN/postinst
         let postinst = format!(
-            "#!/usr/bin/env sh\nln -s /usr/share/{n}/{n} /usr/bin/{n}\nchmod +x /usr/bin/{n}\nexit 0\n",
+            "#!/usr/bin/env sh\nln -s /opt/{n}/{n} /usr/bin/{n}\nchmod +x /usr/bin/{n}\nexit 0\n",
             n = binary_name,
         );
         let postinst_path = debian_dir.join("postinst");

--- a/crates/app_packager/src/linux/pacman.rs
+++ b/crates/app_packager/src/linux/pacman.rs
@@ -44,12 +44,12 @@ impl AppPackager for LinuxPacmanPackager {
         let binary_name = &config.app_binary_name;
 
         // Create directory tree
-        let share_app_dir = pkg_dir.join("usr/share").join(binary_name);
+        let share_app_dir = pkg_dir.join("opt").join(binary_name);
         let applications_dir = pkg_dir.join("usr/share/applications");
         std::fs::create_dir_all(&share_app_dir)?;
         std::fs::create_dir_all(&applications_dir)?;
 
-        // Copy the flutter build output into /usr/share/{binary_name}/
+        // Copy the flutter build output into /opt/{binary_name}/
         run(Command::new("cp").args([
             "-fr",
             &format!("{}/.", config.build_output_dir.display()),
@@ -66,7 +66,7 @@ impl AppPackager for LinuxPacmanPackager {
 
         // Write .INSTALL
         let install = format!(
-            "post_install() {{\n  ln -s /usr/share/{n}/{n} /usr/bin/{n}\n  chmod +x /usr/bin/{n}\n}}\n\
+            "post_install() {{\n  ln -s /opt/{n}/{n} /usr/bin/{n}\n  chmod +x /usr/bin/{n}\n}}\n\
              post_remove() {{\n  rm -f /usr/bin/{n}\n}}\n",
             n = binary_name,
         );
@@ -93,6 +93,7 @@ impl AppPackager for LinuxPacmanPackager {
                 "--options=!all,use-set,type,uid,gid,mode,time,size,md5,sha256,link",
                 ".PKGINFO",
                 ".INSTALL",
+                "opt",
                 "usr",
             ])
             .env("LANG", "C"))?;
@@ -100,7 +101,9 @@ impl AppPackager for LinuxPacmanPackager {
         // Archive with bsdtar
         run(Command::new("bsdtar")
             .current_dir(&pkg_dir)
-            .args(["-cf", "temptar", ".MTREE", ".INSTALL", ".PKGINFO", "usr"])
+            .args([
+                "-cf", "temptar", ".MTREE", ".INSTALL", ".PKGINFO", "opt", "usr",
+            ])
             .env("LANG", "C"))?;
 
         // Compress with xz

--- a/crates/app_packager/src/linux/rpm.rs
+++ b/crates/app_packager/src/linux/rpm.rs
@@ -60,7 +60,7 @@ impl AppPackager for LinuxRpmPackager {
 
         // Write {app_name}.desktop into BUILD/
         let desktop = format!(
-            "[Desktop Entry]\nType=Application\nName={name}\nExec=/usr/share/{bin}/{bin} %U\nIcon={bin}\n",
+            "[Desktop Entry]\nType=Application\nName={name}\nExec=/opt/{bin}/{bin} %U\nIcon={bin}\n",
             name = config.app_name,
             bin = binary_name,
         );
@@ -83,12 +83,12 @@ impl AppPackager for LinuxRpmPackager {
              BuildArch: {arch}\n\n\
              %description\n{name}\n\n\
              %install\n\
-             mkdir -p %{{buildroot}}/usr/share/{bin}\n\
-             cp -r %{{_builddir}}/{name}/. %{{buildroot}}/usr/share/{bin}/\n\
+             mkdir -p %{{buildroot}}/opt/{bin}\n\
+             cp -r %{{_builddir}}/{name}/. %{{buildroot}}/opt/{bin}/\n\
              mkdir -p %{{buildroot}}/usr/share/applications\n\
              cp %{{_builddir}}/{name}.desktop %{{buildroot}}/usr/share/applications/\n\n\
              %files\n\
-             /usr/share/{bin}\n\
+             /opt/{bin}\n\
              /usr/share/applications/{name}.desktop\n",
             name = app_name,
             ver = config.app_version.split('+').next().unwrap_or("0.0.1"),

--- a/packages/flutter_app_packager/lib/src/makers/deb/app_package_maker_deb.dart
+++ b/packages/flutter_app_packager/lib/src/makers/deb/app_package_maker_deb.dart
@@ -42,7 +42,7 @@ class AppPackageMakerDeb extends AppPackageMaker {
 
     /// Need to create following directories
     /// /DEBIAN
-    /// /usr/share/$appBinaryName
+    /// /opt/$appBinaryName
     /// /usr/share/applications
     /// /usr/share/icons/hicolor/128x128/apps
     /// /usr/share/icons/hicolor/256x256/apps
@@ -63,7 +63,7 @@ class AppPackageMakerDeb extends AppPackageMaker {
     final mkdirProcessResult = await $('mkdir', [
       '-p',
       debianDir,
-      path.join(packagingDirectory.path, 'usr/share', makeConfig.appBinaryName),
+      path.join(packagingDirectory.path, 'opt', makeConfig.appBinaryName),
       applicationsDir,
       if (makeConfig.metainfo != null) metainfoDir,
       if (makeConfig.icon != null) ...[icon128Dir, icon256Dir],
@@ -125,11 +125,11 @@ class AppPackageMakerDeb extends AppPackageMaker {
     // give execution permission to shell scripts
     await $('chmod', ['+x', postinstFile.path, postrmFile.path]);
 
-    // copy the application binary to /usr/share/$appBinaryName
+    // copy the application binary to /opt/$appBinaryName
     await $('cp', [
       '-fr',
       '${appDirectory.path}/.',
-      '${packagingDirectory.path}/usr/share/${makeConfig.appBinaryName}/',
+      '${packagingDirectory.path}/opt/${makeConfig.appBinaryName}/',
     ]);
 
     ProcessResult processResult = await $('dpkg-deb', [

--- a/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
@@ -113,10 +113,10 @@ categories:
   - Music
   - Media
 
-# let OS know if the application can be run on start_up. If it's false 
-# the application will deny to the OS if it was added as a start_up 
+# let OS know if the application can be run on start_up. If it's false
+# the application will deny to the OS if it was added as a start_up
 # application
-startup_notify: true  
+startup_notify: true
 */
 
 class MakeDebConfig extends MakeLinuxPackageConfig {
@@ -258,7 +258,7 @@ class MakeDebConfig extends MakeLinuxPackageConfig {
   List<String>? categories;
 
   List<String> get postinstallScripts => [
-        'ln -s /usr/share/$appBinaryName/$appBinaryName /usr/bin/$appBinaryName',
+        'ln -s /opt/$appBinaryName/$appBinaryName /usr/bin/$appBinaryName',
         'chmod +x /usr/bin/$appBinaryName',
         ..._postinstallScripts,
       ];

--- a/packages/flutter_app_packager/lib/src/makers/pacman/app_package_maker_pacman.dart
+++ b/packages/flutter_app_packager/lib/src/makers/pacman/app_package_maker_pacman.dart
@@ -41,7 +41,7 @@ class AppPackageMakerPacman extends AppPackageMaker {
     Directory packagingDirectory = makeConfig.packagingDirectory;
 
     /// Need to create following directories
-    /// /usr/share/$appBinaryName
+    /// /opt/$appBinaryName
     /// /usr/share/applications
     /// /usr/share/icons/hicolor/128x128/apps
     /// /usr/share/icons/hicolor/256x256/apps
@@ -60,7 +60,7 @@ class AppPackageMakerPacman extends AppPackageMaker {
         path.join(packagingDirectory.path, 'usr/share/metainfo');
     final mkdirProcessResult = await $('mkdir', [
       '-p',
-      path.join(packagingDirectory.path, 'usr/share', makeConfig.appBinaryName),
+      path.join(packagingDirectory.path, 'opt', makeConfig.appBinaryName),
       applicationsDir,
       if (makeConfig.metainfo != null) metainfoDir,
       if (makeConfig.icon != null) ...[icon128Dir, icon256Dir],
@@ -116,11 +116,11 @@ class AppPackageMakerPacman extends AppPackageMaker {
     await pkgInfoFile.writeAsString(files['PKGINFO']!);
     await desktopEntryFile.writeAsString(files['DESKTOP']!);
 
-    // copy the application binary to /usr/share/$appBinaryName
+    // copy the application binary to /opt/$appBinaryName
     await $('cp', [
       '-fr',
       '${appDirectory.path}/.',
-      '${packagingDirectory.path}/usr/share/${makeConfig.appBinaryName}/',
+      '${packagingDirectory.path}/opt/${makeConfig.appBinaryName}/',
     ]);
 
     // MTREE Metadata using bsdtar and fakeroot

--- a/packages/flutter_app_packager/lib/src/makers/pacman/make_pacman_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/pacman/make_pacman_config.dart
@@ -88,10 +88,10 @@ categories:
   - Music
   - Media
 
-# let OS know if the application can be run on start_up. If it's false 
-# the application will deny to the OS if it was added as a start_up 
+# let OS know if the application can be run on start_up. If it's false
+# the application will deny to the OS if it was added as a start_up
 # application
-startup_notify: true  
+startup_notify: true
 */
 
 class MakePacmanConfig extends MakeLinuxPackageConfig {
@@ -210,7 +210,7 @@ class MakePacmanConfig extends MakeLinuxPackageConfig {
   List<String>? categories;
 
   List<String> get postinstallScripts => [
-        'ln -s /usr/share/$appBinaryName/$appBinaryName /usr/bin/$appBinaryName',
+        'ln -s /opt/$appBinaryName/$appBinaryName /usr/bin/$appBinaryName',
         'chmod +x /usr/bin/$appBinaryName',
         ..._postinstallScripts,
       ];


### PR DESCRIPTION
This PR changes the default installation directory for `.deb` packages from `/usr/share/{binary_name}` to `/opt/{binary_name}`.

### Motivation

According to the [Filesystem Hierarchy Standard (FHS)](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html), `/usr/share` is intended for **architecture-independent, read-only data** — things like documentation, icons, locale files, and `.desktop` entries. It is not meant to hold application binaries or their runtime dependencies.

`/opt`, on the other hand, is specifically designated for **self-contained, add-on application software packages**. Each application gets its own subtree (`/opt/{package}`), where it can place binaries, libraries, and any other files it needs — without mixing them into the shared system directories.

### Why this matters

| | `/usr/share/{name}` | `/opt/{name}` |
|---|---|---|
| FHS purpose | Static, arch-independent data | Self-contained third-party apps |
| Placing binaries here | Violates FHS | Correct per FHS |
| Isolation | Files mix with system packages | Clean per-app directory |
| Uninstall cleanliness | Scattered files harder to track | Single directory to remove |
| Lintian / rpmlint | May produce warnings | No warnings |

Packaging tools like `lintian` flag binaries placed under `/usr/share` as a policy violation. Moving to `/opt` resolves this and aligns with how other third-party `.deb` distributors (Chrome, VS Code, Discord, Zoom, etc.) package their applications.

### Related Issues
Fixed https://github.com/fastforgedev/fastforge/issues/336