### PR TITLE
Feat/rpm spec macros

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -35,6 +35,7 @@ class MakeRPMConfig extends MakeConfig {
     this.defattr,
     this.attr,
     this.changelog,
+    this.specMacros,
   });
 
   factory MakeRPMConfig.fromJson(Map<String, dynamic> json) {
@@ -68,6 +69,7 @@ class MakeRPMConfig extends MakeConfig {
       defattr: json['defattr'] as String?,
       attr: json['attr'] as String?,
       changelog: json['changelog'] as String?,
+      specMacros: (json['spec_macros'] as List<dynamic>?)?.cast<String>(),
     );
   }
 
@@ -102,6 +104,7 @@ class MakeRPMConfig extends MakeConfig {
   String? defattr;
   String? attr;
   String? changelog;
+  List<String>? specMacros;
 
   @override
   Map<String, dynamic> toJson() {
@@ -200,9 +203,12 @@ class MakeRPMConfig extends MakeConfig {
             (e) => '${e.key}=${e.value}',
           ),
     ].join('\n');
+    final macrosStr = specMacros != null && specMacros!.isNotEmpty
+        ? '${specMacros!.join('\n')}\n\n'
+        : '';
     final map = {
       'DESKTOP': desktopFile,
-      'SPEC': '$preamble\n\n$body\n\n$inlineBody',
+      'SPEC': '$macrosStr$preamble\n\n$body\n\n$inlineBody',
     };
     return Map.castFrom<String, String?, String, String>(map);
   }


### PR DESCRIPTION
Fixes #330 

* feat: add support for rpm spec macros configuration

- Add spec_macros list parameter to MakeRPMConfig
- Update JSON/YAML parser to safely handle spec_macros array
- Prepend spec macros at the absolute top of the generated .spec file string
- Allow developers to pass global RPM directives (like %global or %define)
- Solve cross-distro ABI conflicts (e.g., libcurl auto-requires) by enabling custom exclusions

Usage in linux/packaging/rpm/make_config.yaml:
spec_macros:
  - "%global __requires_exclude .*libcurl.*CURL_OPENSSL.*"