### PR TITLE
fix(qiniu): clamp sent value within bounds and upgrade qiniu_sdk_base

### DIFF
--- a/packages/flutter_app_publisher/lib/src/publishers/qiniu/app_package_publisher_qiniu.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/qiniu/app_package_publisher_qiniu.dart
@@ -56,7 +56,7 @@ class AppPackagePublisherQiniu extends AppPackagePublisher {
 
       putController.addSendProgressListener((double percent) {
         if (onPublishProgress != null) {
-          sent = (total * percent).toInt();
+          sent = (total * percent).round().clamp(0, total);
           onPublishProgress(sent, total);
         }
       });

--- a/packages/flutter_app_publisher/pubspec.yaml
+++ b/packages/flutter_app_publisher/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   parse_app_package: ^0.6.0
   pub_semver: ^2.2.0
   pubspec_parse: ^1.1.0
-  qiniu_sdk_base: ^0.5.0
+  qiniu_sdk_base: ^0.8.0
   shell_executor: ^0.3.0
 
 dev_dependencies:


### PR DESCRIPTION
## 修复内容

修复 #276 — 上传到七牛在进度 100% 后抛出 `PublishError: null - Invalid argument(s): Start value must be between 0 and total value` 的问题。

### 根因

Qiniu SDK 分片上传的进度上报中，`sentBytes` 以 `double` 跨分片累加，浮点累积误差可能使 `percent > 1.0`。fastforge 发布器计算 `sent = (total * percent).toInt()` 后传给 `ProgressBar.start(total, sent)`，当 `sent > total` 时 ProgressBar 抛出 `ArgumentError`，该错误经 Dio → Qiniu SDK 逐层包装后以 `StorageError` 抛出。

### 修改

| 文件 | 变更 |
|------|------|
| `pubspec.yaml` | `qiniu_sdk_base: ^0.5.0` → `^0.8.0` |
| `app_package_publisher_qiniu.dart` | `.toInt()` → `.round().clamp(0, total)` |

双重保险：
1. **升级 Qiniu SDK** — 获取上游最新修复
2. **钳制 sent** — 即使上游汇报 `percent > 1.0`，`.clamp(0, total)` 也能确保 `sent` 永不越界

### 测试

- `dart analyze`: ✅ No issues found
- `dart test`: ✅ 19/19 All tests passed