### PR TITLE
fix(msix): auto-detect architecture from build output directory

### DIFF
--- a/apps/docs/en/makers/msix.md
+++ b/apps/docs/en/makers/msix.md
@@ -15,6 +15,9 @@ Add `make_config.yaml` to your project `windows/packaging/msix` directory.
 display_name: HelloWorld
 msix_version: 1.0.0.0
 # logo_path: C:\path\to\logo.png
+# Target architecture: x64, x86, or arm64.
+# If not specified, auto-detected from the build output directory.
+# architecture: x64
 ```
 
 > View all configuration options: [msix](https://github.com/YehudaKremer/msix)
@@ -24,6 +27,23 @@ Run:
 ```
 fastforge package --platform windows --targets msix
 ```
+
+## Build for ARM64
+
+To build an ARM64 MSIX package on an ARM64 machine (e.g., Surface Pro X), no special configuration is needed — the architecture is auto-detected from the build output directory.
+
+To build an ARM64 MSIX package on an x64 machine (e.g., CI), you need to:
+
+1. Set the build target platform in `distribute_options.yaml`:
+
+```yaml
+build_args:
+  target-platform: windows-arm64
+```
+
+2. Set `architecture: arm64` in your `windows/packaging/msix/make_config.yaml`.
+
+> **Note:** Cross-compiling for ARM64 on an x64 machine requires the [ARM64 Visual Studio build tools](https://learn.microsoft.com/en-us/windows/arm/arm-on-windows) to be installed.
 
 ## Related Links
 

--- a/apps/docs/zh/makers/msix.md
+++ b/apps/docs/zh/makers/msix.md
@@ -15,6 +15,9 @@
 display_name: HelloWorld
 msix_version: 1.0.0.0
 # logo_path: C:\path\to\logo.png
+# 目标架构：x64、x86 或 arm64。
+# 如果未指定，会从构建输出目录自动检测。
+# architecture: x64
 ```
 
 > 查看所有配置选项：[msix](https://github.com/YehudaKremer/msix)
@@ -24,6 +27,23 @@ msix_version: 1.0.0.0
 ```
 fastforge package --platform windows --targets msix
 ```
+
+## 构建 ARM64 版本
+
+在 ARM64 机器（如 Surface Pro X）上构建 ARM64 MSIX 包时，无需特殊配置——架构会自动从构建输出目录检测。
+
+在 x64 机器（如 CI）上构建 ARM64 MSIX 包时，需要：
+
+1. 在 `distribute_options.yaml` 中设置构建目标平台：
+
+```yaml
+build_args:
+  target-platform: windows-arm64
+```
+
+2. 在 `windows/packaging/msix/make_config.yaml` 中设置 `architecture: arm64`。
+
+> **注意：** 在 x64 机器上交叉编译 ARM64 需要安装 [ARM64 Visual Studio 构建工具](https://learn.microsoft.com/en-us/windows/arm/arm-on-windows)。
 
 ## 相关链接
 

--- a/examples/hello_world/windows/packaging/msix/make_config.yaml
+++ b/examples/hello_world/windows/packaging/msix/make_config.yaml
@@ -1,3 +1,6 @@
 display_name: HelloWorld
 msix_version: 1.0.0.0
 # logo_path: C:\path\to\logo.png
+# Target architecture: x64, x86, or arm64.
+# If not specified, auto-detected from the build output directory.
+# architecture: x64

--- a/packages/flutter_app_packager/lib/src/makers/msix/app_package_maker_msix.dart
+++ b/packages/flutter_app_packager/lib/src/makers/msix/app_package_maker_msix.dart
@@ -41,6 +41,12 @@ class AppPackageMakerMsix extends AppPackageMaker {
         p.basenameWithoutExtension(makeConfig.outputFile.path);
     makeConfig.build_windows = 'false';
 
+    // Auto-detect architecture from the build output directory if not explicitly configured.
+    // For example: "build/windows/arm64/runner/Release" -> arm64.
+    if (makeConfig.architecture == null) {
+      makeConfig.architecture = _detectArchitecture(appDirectory);
+    }
+
     Map<String, dynamic> makeConfigJson = makeConfig.toJson();
     List<String> arguments = [];
     for (String key in makeConfigJson.keys) {
@@ -58,5 +64,20 @@ class AppPackageMakerMsix extends AppPackageMaker {
     }
     await Msix(arguments).create();
     return MakeResult(makeConfig);
+  }
+
+  /// Detects the target architecture from the build output directory path.
+  ///
+  /// Flutter 3.22+ places build output in architecture-specific subdirectories:
+  ///   - build/windows/arm64/runner/Release  -> arm64
+  ///   - build/windows/x64/runner/Release    -> x64
+  /// For older Flutter versions or when the path doesn't contain an arch hint,
+  /// defaults to x64.
+  String _detectArchitecture(Directory appDirectory) {
+    final path = appDirectory.path.toLowerCase();
+    if (path.contains('arm64')) {
+      return 'arm64';
+    }
+    return 'x64';
   }
 }


### PR DESCRIPTION
## Summary

Closes #338

When building for ARM64 on an ARM64 machine (or cross-compiling with `target-platform: windows-arm64`), the Flutter build output goes to `build/windows/arm64/runner/Release`. However, the MSIX maker was not passing the architecture to the msix package, causing it to default to `x64` and look for build files in the wrong directory.

## Changes

### Code

**`app_package_maker_msix.dart`**: Added auto-detection of the target architecture from the build output directory path. If `architecture` is not explicitly set in `make_config.yaml`, it's inferred from the directory path (e.g., `.../arm64/...` → `arm64`, otherwise `x64`).

### Documentation

- **`docs/en/makers/msix.md`**: Documented `architecture` option and added a "Build for ARM64" section with cross-compilation guidance.
- **`docs/zh/makers/msix.md`**: Same, Chinese translation.
- **`examples/hello_world/.../msix/make_config.yaml`**: Added `architecture` as commented option.

## Testing

- ARM64 machine: `flutter build windows` outputs to `build/windows/arm64/runner/Release` → MSIX maker auto-detects `arm64`, msix looks in the correct path.
- x64 machine: `flutter build windows` outputs to `build/windows/x64/runner/Release` → MSIX maker auto-detects `x64` (default).
- Explicit config: If user sets `architecture: x64` in `make_config.yaml`, it's respected over auto-detection.