### PR TITLE
feat(rpm): add support for custom package_name to rename package artifacts

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -6,6 +6,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
   MakeRPMConfig({
     // Desktop file
     required this.displayName,
+    this.packageName,
     this.startupNotify = true,
     this.actions,
     this.categories,
@@ -44,6 +45,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
   factory MakeRPMConfig.fromJson(Map<String, dynamic> json) {
     return MakeRPMConfig(
       displayName: json['display_name'] as String,
+      packageName: json['package_name'] as String?,
       icon: json['icon'] as String?,
       metainfo: json['metainfo'] as String?,
       genericName: json['generic_name'] as String?,
@@ -83,6 +85,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
   }
 
   String displayName;
+  String? packageName;
   String? icon;
   String? metainfo;
   String? genericName;
@@ -133,7 +136,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
     return {
       'SPEC': {
         'preamble': {
-          'Name': appName,
+          'Name': packageName ?? appName,
           'Version': appVersion.toString(),
           'Release':
               "${appVersion.build.isNotEmpty ? appVersion.build.first : "1"}%{?dist}",
@@ -156,7 +159,7 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
             'mkdir -p %{buildroot}%{_datadir}/applications',
             'mkdir -p %{buildroot}%{_datadir}/metainfo',
             'mkdir -p %{buildroot}%{_datadir}/pixmaps',
-            'cp -r %{name}/* %{buildroot}%{_datadir}/%{name}',
+            'cp -r $appName/* %{buildroot}%{_datadir}/%{name}',
             'ln -s %{_datadir}/%{name}/$appBinaryName %{buildroot}%{_bindir}/%{name}',
             'cp -r $appBinaryName.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop',
             'cp -r $appBinaryName.png %{buildroot}%{_datadir}/pixmaps/%{name}.png',
@@ -180,8 +183,8 @@ class MakeRPMConfig extends MakeLinuxPackageConfig {
         'Type': 'Application',
         'Name': displayName,
         'GenericName': genericName,
-        'Icon': appName,
-        'Exec': '$appName %U',
+        'Icon': packageName ?? appName,
+        'Exec': '${packageName ?? appName} %U',
         'Actions': actions != null && actions!.isNotEmpty
             ? '${actions!.join(';')};'
             : null,

--- a/packages/flutter_app_packager/test/src/makers/linux_desktop_entry_test.dart
+++ b/packages/flutter_app_packager/test/src/makers/linux_desktop_entry_test.dart
@@ -49,6 +49,34 @@ void main() {
 
       expect(files['SPEC'], contains('Version: 1.2.3+4'));
       expect(files['DESKTOP'], isNot(contains('\nVersion=')));
+      expect(files['DESKTOP'], contains('Icon=test_app'));
+      expect(files['DESKTOP'], contains('Exec=test_app %U'));
+    });
+
+    test('rpm keeps package, project, and binary names independent', () {
+      File('${tempDir.path}/linux/CMakeLists.txt')
+          .writeAsStringSync('set(BINARY_NAME "test_binary")\n');
+      final config = MakeRPMConfig(
+        displayName: 'Test App',
+        packageName: 'test-package',
+      )..pubspec = _pubspec();
+
+      final files = config.toFilesString();
+
+      expect(files['SPEC'], contains('Name: test-package'));
+      expect(
+        files['SPEC'],
+        contains('cp -r test_app/* %{buildroot}%{_datadir}/%{name}'),
+      );
+      expect(
+        files['SPEC'],
+        contains(
+          'ln -s %{_datadir}/%{name}/test_binary '
+          '%{buildroot}%{_bindir}/%{name}',
+        ),
+      );
+      expect(files['DESKTOP'], contains('Icon=test-package'));
+      expect(files['DESKTOP'], contains('Exec=test-package %U'));
     });
 
     test('rpm places lifecycle scripts outside the install section', () {


### PR DESCRIPTION
Fixes https://github.com/fastforgedev/fastforge/issues/314


- Introduced `package_name` support in `MakeRPMConfig` (parity with Deb maker).
- Updated Spec generation to use `package_name` (if provided) for:
  - The RPM package Name.
  - The installation directory (`/usr/share/<package_name>`).
  - The executable symlink in `/usr/bin/<package_name>`.
  - The naming of .desktop, .png, and .xml assets.
  - The `Exec` command in the desktop entry.
- Decoupled the internal `appBinaryName` (source) from the system-facing package identity (destination).